### PR TITLE
fix(tasks): handle FastAPI array detail in error messages

### DIFF
--- a/src/context/TaskContext.tsx
+++ b/src/context/TaskContext.tsx
@@ -9,6 +9,16 @@ import {
 } from 'react';
 import { stripMentionSyntax } from '../lib/mentions';
 
+function extractDetail(data: unknown, fallback: string): string {
+  const detail = (data as { detail?: unknown } | null)?.detail;
+  if (!detail) return fallback;
+  if (typeof detail === 'string') return detail;
+  if (Array.isArray(detail)) {
+    return detail.map((d: unknown) => (d as { msg?: string })?.msg ?? String(d)).join(', ');
+  }
+  return fallback;
+}
+
 export interface Task {
   id: string;
   title: string;
@@ -212,10 +222,7 @@ export function TaskProvider({ children }: { children: ReactNode }) {
       path: '/tasks',
       body: input,
     });
-    if (!res.ok) {
-      const detail = (res.data as { detail?: string } | null)?.detail;
-      throw new Error(detail || 'Failed to create task');
-    }
+    if (!res.ok) throw new Error(extractDetail(res.data, 'Failed to create task'));
     await loadTasks();
     return res.data as Task;
   }, [loadTasks]);
@@ -226,10 +233,7 @@ export function TaskProvider({ children }: { children: ReactNode }) {
       path: `/tasks/${id}`,
       body: input,
     });
-    if (!res.ok) {
-      const detail = (res.data as { detail?: string } | null)?.detail;
-      throw new Error(detail || 'Failed to update task');
-    }
+    if (!res.ok) throw new Error(extractDetail(res.data, 'Failed to update task'));
     await loadTasks();
   }, [loadTasks]);
 
@@ -777,10 +781,7 @@ export function TaskProvider({ children }: { children: ReactNode }) {
           pending_expert_id: needsReassign ? targetExpertId : null,
         },
       });
-      if (!res.ok) {
-        const detail = (res.data as { detail?: string } | null)?.detail;
-        throw new Error(detail || 'Failed to queue instruction');
-      }
+      if (!res.ok) throw new Error(extractDetail(res.data, 'Failed to queue instruction'));
       await loadTasks();
       return;
     }


### PR DESCRIPTION
  **Summary**                                                   

  - FastAPI 422 validation errors return detail as an array of objects ([{loc, msg, type}]), not a string. The task context was passing it directly to new Error(), which called .toString() on the array and produced the message "[object Object]".                                                                   
  - Adds extractDetail() helper that handles detail as either a string or an array, joining .msg fields when it's an array.                                                                                           
  - Fixes createTask, updateTask, and queueInstruction error paths.
                                                                                                            
  **Test plan**                                                 
                                                                                                            
  - Create a task with a title exceeding 200 characters — should show a readable validation message instead of [object Object]
  - Trigger a backend validation error on task create/update and verify the error message is human-readable 
  - Happy path: create, update, and queue instructions on tasks still work normally