### PR TITLE
fix(linux): resolve Linux compatibility issues across UI, main process

### DIFF
--- a/src/components/screens/settings/SandboxSection.tsx
+++ b/src/components/screens/settings/SandboxSection.tsx
@@ -162,8 +162,8 @@ export default function SandboxSection() {
     }
     if (enabled && !platformSupported) {
       return (
-        <span className="inline-flex items-center gap-1.5 text-[11px] font-medium text-amber-300 bg-amber-500/15 border border-amber-500/30 px-2.5 py-1 rounded-full">
-          <AlertTriangle size={12} /> Unsupported platform
+        <span className="inline-flex items-center gap-1.5 text-[11px] font-medium text-text-tertiary bg-bg-elevated border border-border-subtle px-2.5 py-1 rounded-full">
+          <ShieldOff size={12} /> {t('sandbox.macOsOnly')}
         </span>
       );
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -829,7 +829,7 @@ function registerIpcHandlers(): void {
     const [parent] = BrowserWindow.getAllWindows();
     const result = await dialog.showOpenDialog(parent, {
       title: 'Link a project directory',
-      message: 'Cerebro will grant its agents access to this directory.',
+      ...(process.platform === 'darwin' ? { message: 'Cerebro will grant its agents access to this directory.' } : {}),
       properties: ['openDirectory', 'createDirectory'],
     });
     if (result.canceled || result.filePaths.length === 0) return null;
@@ -917,8 +917,10 @@ const createWindow = () => {
     minHeight: 600,
     title: 'Cerebro',
     icon: path.join(app.getAppPath(), 'assets', 'icon.png'),
-    titleBarStyle: 'hiddenInset',
-    trafficLightPosition: { x: 16, y: 12 },
+    ...(process.platform === 'darwin' ? {
+      titleBarStyle: 'hiddenInset' as const,
+      trafficLightPosition: { x: 16, y: 12 },
+    } : {}),
     backgroundColor: '#09090b',
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),

--- a/src/telegram/__tests__/helpers.test.ts
+++ b/src/telegram/__tests__/helpers.test.ts
@@ -52,16 +52,20 @@ describe('parseAllowlistRaw', () => {
 });
 
 describe('redactForChat', () => {
-  const dataDir = '/Users/alice/Library/Application Support/Cerebro';
+  const macDataDir = '/Users/alice/Library/Application Support/Cerebro';
+  const linuxDataDir = '/home/alice/.config/Cerebro';
 
   it('scrubs bot tokens', () => {
     const text = 'leaked: 123456789:AAEabcdefghijklmnopqrstuvwxy123 end';
-    const out = redactForChat(text, dataDir);
+    const out = redactForChat(text, macDataDir);
     expect(out).not.toContain('AAEabcdefghijklmnopqrstuvwxy123');
     expect(out).toContain('***');
   });
 
-  it('masks paths under the data dir', () => {
+  it.each([
+    ['macOS', macDataDir],
+    ['Linux', linuxDataDir],
+  ])('masks paths under the data dir (%s)', (_platform, dataDir) => {
     const text = `see ${dataDir}/telegram-tmp/abc.ogg for details`;
     const out = redactForChat(text, dataDir);
     expect(out).not.toContain('telegram-tmp/abc.ogg');
@@ -70,14 +74,14 @@ describe('redactForChat', () => {
 
   it('masks generic sk-* keys', () => {
     const text = 'api key: sk-proj-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    const out = redactForChat(text, dataDir);
+    const out = redactForChat(text, macDataDir);
     expect(out).toContain('<key>');
     expect(out).not.toMatch(/sk-proj-[A-Z0-9]{20,}/);
   });
 
   it('leaves ordinary text intact', () => {
     const text = 'Nothing sensitive here.';
-    expect(redactForChat(text, dataDir)).toBe(text);
+    expect(redactForChat(text, macDataDir)).toBe(text);
   });
 });
 


### PR DESCRIPTION
  **Summary**                                                                                                   
                  
  - Guard macOS-only Electron APIs (titleBarStyle, trafficLightPosition, dialog.message) behind process.platform === 'darwin' checks
  - Replace amber "Unsupported platform" sandbox status pill with a neutral "macOS only" label on non-macOS platforms                                                                                                 
  - Expand redactForChat path-masking test to cover both macOS and Linux dataDir formats
                                                                                                            
  **Test plan**       
                                                                                                            
  - Run npm test — the updated redactForChat test should pass with both macOS and Linux paths               
  - Launch app on Linux — no console errors about unknown titleBarStyle or trafficLightPosition
  - Open Settings → Sandbox on Linux — status pill shows "macOS only" in neutral style instead of amber  "Unsupported platform"                                                                                    
  - Open a project folder picker on Linux — dialog opens without errors