### PR TITLE
feat(integrations): GoHighLevel outbound contact sync

### DIFF
--- a/backend/integrations/ghl.py
+++ b/backend/integrations/ghl.py
@@ -32,9 +32,9 @@ class GHLClient:
         async with httpx.AsyncClient(base_url=GHL_BASE_URL, headers=self._headers) as client:
             # 1. Search first
             try:
-                resp = await client.get(
+                resp = await client.post(
                     "/contacts/search",
-                    params={"locationId": self.location_id, "query": practice_name},
+                    json={"locationId": self.location_id, "searchAfter": [], "filters": [], "query": practice_name, "pageLimit": 1},
                     timeout=10.0,
                 )
                 resp.raise_for_status()

--- a/backend/integrations/ghl.py
+++ b/backend/integrations/ghl.py
@@ -1,0 +1,94 @@
+"""GoHighLevel API client.
+
+Failures are logged but never re-raised so a broken GHL config cannot
+interrupt task completion in the rest of the system.
+"""
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+GHL_BASE_URL = "https://services.leadconnectorhq.com"
+GHL_API_VERSION = "2021-07-28"
+
+
+class GHLClient:
+    def __init__(self, api_key: str, location_id: str) -> None:
+        self.location_id = location_id
+        self._headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Version": GHL_API_VERSION,
+            "Content-Type": "application/json",
+        }
+
+    async def find_or_create_contact(self, practice_name: str) -> str | None:
+        """Return existing contact_id or create one and return its id.
+
+        Returns None on any API error so callers can short-circuit gracefully.
+        """
+        async with httpx.AsyncClient(base_url=GHL_BASE_URL, headers=self._headers) as client:
+            # 1. Search first
+            try:
+                resp = await client.get(
+                    "/contacts/search",
+                    params={"locationId": self.location_id, "query": practice_name},
+                    timeout=10.0,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                contacts = data.get("contacts", [])
+                if contacts:
+                    contact_id: str = contacts[0]["id"]
+                    logger.debug("GHL: found existing contact %s for %r", contact_id, practice_name)
+                    return contact_id
+            except Exception as exc:
+                logger.error("GHL: contact search failed for %r: %s", practice_name, exc)
+                return None
+
+            # 2. Create if not found
+            try:
+                parts = practice_name.strip().split(" ", 1)
+                first_name = parts[0]
+                last_name = parts[1] if len(parts) > 1 else ""
+                resp = await client.post(
+                    "/contacts/",
+                    json={
+                        "locationId": self.location_id,
+                        "firstName": first_name,
+                        "lastName": last_name,
+                        "tags": ["cerebro-brief"],
+                    },
+                    timeout=10.0,
+                )
+                resp.raise_for_status()
+                contact_id = resp.json()["contact"]["id"]
+                logger.info("GHL: created contact %s for %r", contact_id, practice_name)
+                return contact_id
+            except Exception as exc:
+                logger.error("GHL: contact creation failed for %r: %s", practice_name, exc)
+                return None
+
+    async def add_note(self, contact_id: str, note_body: str) -> None:
+        """POST a note to an existing GHL contact."""
+        async with httpx.AsyncClient(base_url=GHL_BASE_URL, headers=self._headers) as client:
+            try:
+                resp = await client.post(
+                    f"/contacts/{contact_id}/notes",
+                    json={"body": note_body, "userId": "cerebro"},
+                    timeout=10.0,
+                )
+                resp.raise_for_status()
+                logger.info("GHL: note added to contact %s", contact_id)
+            except Exception as exc:
+                logger.error("GHL: failed to add note to contact %s: %s", contact_id, exc)
+
+    async def push_intel_brief(self, task_title: str, brief_md: str) -> None:
+        """Orchestrate: find/create contact then attach the intel brief as a note."""
+        contact_id = await self.find_or_create_contact(task_title)
+        if contact_id is None:
+            logger.warning("GHL: skipping note — no contact id resolved for %r", task_title)
+            return
+        await self.add_note(contact_id, brief_md)

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -1,0 +1,81 @@
+"""FastAPI router for outbound integration config endpoints — /integrations/*."""
+from __future__ import annotations
+
+import logging
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import Setting, _utcnow
+
+from .schemas import GHLConfig, GHLConfigResponse
+
+router = APIRouter(tags=["integrations"])
+logger = logging.getLogger(__name__)
+
+GHL_BASE_URL = "https://services.leadconnectorhq.com"
+GHL_API_VERSION = "2021-07-28"
+
+# ── Settings helpers ──────────────────────────────────────────────────────────
+
+
+def _upsert_setting(db: Session, key: str, value: str) -> None:
+    setting = db.get(Setting, key)
+    if setting:
+        setting.value = value
+        setting.updated_at = _utcnow()
+    else:
+        setting = Setting(key=key, value=value)
+        db.add(setting)
+
+
+def _get_setting(db: Session, key: str) -> str | None:
+    setting = db.get(Setting, key)
+    return setting.value if setting else None
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
+
+@router.get("/ghl/config", response_model=GHLConfigResponse)
+def get_ghl_config(db: Session = Depends(get_db)) -> GHLConfigResponse:
+    api_key = _get_setting(db, "ghl_api_key")
+    location_id = _get_setting(db, "ghl_location_id") or ""
+    return GHLConfigResponse(location_id=location_id, api_key_set=bool(api_key))
+
+
+@router.put("/ghl/config", response_model=GHLConfigResponse)
+def put_ghl_config(body: GHLConfig, db: Session = Depends(get_db)) -> GHLConfigResponse:
+    _upsert_setting(db, "ghl_api_key", body.api_key)
+    _upsert_setting(db, "ghl_location_id", body.location_id)
+    db.commit()
+    return GHLConfigResponse(location_id=body.location_id, api_key_set=True)
+
+
+@router.post("/ghl/test")
+async def test_ghl_connection(db: Session = Depends(get_db)) -> dict:
+    api_key = _get_setting(db, "ghl_api_key")
+    location_id = _get_setting(db, "ghl_location_id")
+
+    if not api_key or not location_id:
+        raise HTTPException(status_code=400, detail="GHL credentials not configured")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Version": GHL_API_VERSION,
+    }
+    try:
+        async with httpx.AsyncClient(base_url=GHL_BASE_URL, headers=headers) as client:
+            resp = await client.get(
+                "/contacts/search",
+                params={"locationId": location_id, "query": "test"},
+                timeout=10.0,
+            )
+            resp.raise_for_status()
+        return {"ok": True, "status_code": resp.status_code}
+    except httpx.HTTPStatusError as exc:
+        return {"ok": False, "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}"}
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}

--- a/backend/integrations/router.py
+++ b/backend/integrations/router.py
@@ -69,8 +69,7 @@ async def test_ghl_connection(db: Session = Depends(get_db)) -> dict:
     try:
         async with httpx.AsyncClient(base_url=GHL_BASE_URL, headers=headers) as client:
             resp = await client.get(
-                "/contacts/search",
-                params={"locationId": location_id, "query": "test"},
+                f"/locations/{location_id}",
                 timeout=10.0,
             )
             resp.raise_for_status()

--- a/backend/integrations/schemas.py
+++ b/backend/integrations/schemas.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class GHLConfig(BaseModel):
+    api_key: str
+    location_id: str
+
+
+class GHLConfigResponse(BaseModel):
+    location_id: str
+    api_key_set: bool  # never return the actual key

--- a/backend/main.py
+++ b/backend/main.py
@@ -30,6 +30,7 @@ from sandbox.router import router as sandbox_router
 from tasks.router import router as tasks_router
 from sync.router import router as sync_router
 from files.router import router as files_router
+from integrations.router import router as integrations_router
 
 
 @asynccontextmanager
@@ -87,6 +88,7 @@ app.include_router(sandbox_router, prefix="/sandbox")
 app.include_router(tasks_router, prefix="/tasks")
 app.include_router(sync_router, prefix="/sync")
 app.include_router(files_router, prefix="/files")
+app.include_router(integrations_router, prefix="/integrations")
 
 
 @app.get("/health")

--- a/backend/tasks/router.py
+++ b/backend/tasks/router.py
@@ -1,4 +1,6 @@
+import asyncio
 import json
+import logging
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -6,8 +8,10 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from database import get_db
-from models import Expert, RunRecord, Task, TaskChecklistItem, TaskComment
+from models import Expert, RunRecord, Setting, Task, TaskChecklistItem, TaskComment
 from sandbox.validation import cerebro_data_dir, validate_link_path
+
+logger = logging.getLogger(__name__)
 
 from .schemas import (
     ChecklistItemCreate,
@@ -305,9 +309,41 @@ def cancel_task(task_id: str, db: Session = Depends(get_db)):
 
 TERMINAL_EVENTS = {"run_completed", "run_failed", "run_cancelled"}
 
+# Sales Intel Analyst expert — fires GHL contact sync on task completion.
+SALES_INTEL_ANALYST_ID = "91be7fc45ee045aca27e7ffb28103900"
+
+
+async def _push_to_ghl(db: Session, task: Task) -> None:
+    """Push a completed intel brief to GoHighLevel as a contact + note.
+
+    All exceptions are caught and logged. A GHL failure must never propagate
+    up and disrupt the task-completion flow.
+    """
+    try:
+        from integrations.ghl import GHLClient
+
+        api_key_row = db.get(Setting, "ghl_api_key")
+        location_id_row = db.get(Setting, "ghl_location_id")
+
+        if not api_key_row or not location_id_row:
+            logger.debug("GHL push skipped — credentials not configured")
+            return
+
+        client = GHLClient(
+            api_key=api_key_row.value,
+            location_id=location_id_row.value,
+        )
+        await client.push_intel_brief(
+            task_title=task.title,
+            brief_md=task.description_md or "",
+        )
+        logger.info("GHL push complete for task %s (%r)", task.id, task.title)
+    except Exception:
+        logger.exception("GHL push failed for task %s — continuing", task.id)
+
 
 @router.post("/{task_id}/run-event")
-def handle_run_event(task_id: str, event: dict, db: Session = Depends(get_db)):
+async def handle_run_event(task_id: str, event: dict, db: Session = Depends(get_db)):
     task = db.get(Task, task_id)
     if not task:
         raise HTTPException(404, "Task not found")
@@ -354,6 +390,9 @@ def handle_run_event(task_id: str, event: dict, db: Session = Depends(get_db)):
                     run.status = "completed"
                     run.completed_at = _utcnow()
             _add_system_comment(db, task.id, "Expert finished — ready for review")
+            # Fire GHL integration for the Sales Intel Analyst expert.
+            if task.expert_id == SALES_INTEL_ANALYST_ID:
+                asyncio.create_task(_push_to_ghl(db, task))
         elif event_type == "run_failed":
             task.column = "error"
             task.last_error = event.get("error", "Unknown error")

--- a/src/components/icons/BrandIcons.tsx
+++ b/src/components/icons/BrandIcons.tsx
@@ -107,6 +107,14 @@ export function WhatsAppIcon({ size = 24, className }: IconProps) {
   );
 }
 
+export function GHLIcon({ size = 24, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm0 4.5a7.5 7.5 0 1 1 0 15 7.5 7.5 0 0 1 0-15zm0 2.25a5.25 5.25 0 1 0 0 10.5 5.25 5.25 0 0 0 0-10.5zm.75 2.25v3.19l2.53 1.46-.75 1.3-3.03-1.75V9h1.25z" />
+    </svg>
+  );
+}
+
 export function HubSpotIcon({ size = 24, className }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" className={className}>

--- a/src/components/screens/integrations/ConnectedAppsSection.tsx
+++ b/src/components/screens/integrations/ConnectedAppsSection.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState, type ComponentType } from 'react';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import {
+  GHLIcon,
   GoogleCalendarIcon,
   GmailIcon,
   HubSpotIcon,
@@ -11,6 +12,7 @@ import {
 import IntegrationCard from './IntegrationCard';
 import HubSpotSection from './HubSpotSection';
 import HubSpotConnectModal from './HubSpotConnectModal';
+import GHLSection from './GHLSection';
 import type { HubSpotStatusResponse } from '../../../types/ipc';
 
 interface Service {
@@ -142,6 +144,17 @@ export default function ConnectedAppsSection() {
           }}
         >
           <HubSpotSection key={reloadKey} />
+        </IntegrationCard>
+
+        <IntegrationCard
+          icon={GHLIcon}
+          iconBg="bg-indigo-500/15"
+          iconColor="text-indigo-400"
+          name="GoHighLevel"
+          description={t('connectedApps.ghlDesc')}
+          defaultExpanded={false}
+        >
+          <GHLSection />
         </IntegrationCard>
       </div>
 

--- a/src/components/screens/integrations/GHLSection.tsx
+++ b/src/components/screens/integrations/GHLSection.tsx
@@ -1,0 +1,231 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { CheckCircle2, Eye, EyeOff, Loader2, XCircle } from 'lucide-react';
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+
+interface GHLConfig {
+  api_key_set: boolean;
+  location_id: string;
+}
+
+type TestState =
+  | { kind: 'idle' }
+  | { kind: 'testing' }
+  | { kind: 'ok' }
+  | { kind: 'err'; error: string };
+
+export default function GHLSection() {
+  const { t } = useTranslation();
+  const [config, setConfig] = useState<GHLConfig | null>(null);
+  const [apiKey, setApiKey] = useState('');
+  const [locationId, setLocationId] = useState('');
+  const [showKey, setShowKey] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [testState, setTestState] = useState<TestState>({ kind: 'idle' });
+  const [savedFlash, setSavedFlash] = useState(false);
+  const flashRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const loadConfig = useCallback(async () => {
+    const res = await window.cerebro.invoke<GHLConfig>({
+      method: 'GET',
+      path: '/integrations/ghl/config',
+    });
+    if (res.ok) {
+      setConfig(res.data);
+      setLocationId(res.data.location_id ?? '');
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadConfig();
+  }, [loadConfig]);
+
+  useEffect(() => () => {
+    if (flashRef.current) clearTimeout(flashRef.current);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!apiKey.trim() || !locationId.trim()) return;
+    const res = await window.cerebro.invoke<GHLConfig>({
+      method: 'PUT',
+      path: '/integrations/ghl/config',
+      body: { api_key: apiKey.trim(), location_id: locationId.trim() },
+    });
+    if (res.ok) {
+      setConfig(res.data);
+      setApiKey('');
+      setEditing(false);
+      setShowKey(false);
+      setTestState({ kind: 'idle' });
+      setSavedFlash(true);
+      if (flashRef.current) clearTimeout(flashRef.current);
+      flashRef.current = setTimeout(() => setSavedFlash(false), 1_500);
+    }
+  }, [apiKey, locationId]);
+
+  const handleTest = useCallback(async () => {
+    setTestState({ kind: 'testing' });
+    const res = await window.cerebro.invoke<{ ok: boolean; error?: string }>({
+      method: 'POST',
+      path: '/integrations/ghl/test',
+    });
+    if (res.data?.ok) {
+      setTestState({ kind: 'ok' });
+    } else {
+      setTestState({ kind: 'err', error: res.data?.error ?? t('ghlSection.testFailed') });
+    }
+  }, [t]);
+
+  const handleDisconnect = useCallback(async () => {
+    await window.cerebro.invoke({
+      method: 'PUT',
+      path: '/integrations/ghl/config',
+      body: { api_key: '', location_id: '' },
+    });
+    setConfig(null);
+    setApiKey('');
+    setLocationId('');
+    setEditing(false);
+    setTestState({ kind: 'idle' });
+  }, []);
+
+  const configured = Boolean(config?.api_key_set);
+  const showForm = !configured || editing;
+
+  return (
+    <div className="space-y-4">
+      {/* API Key */}
+      <div>
+        <label className="text-xs font-medium text-text-secondary">{t('ghlSection.apiKeyLabel')}</label>
+        <p className="text-[11px] text-text-tertiary mt-1 leading-relaxed">
+          {t('ghlSection.apiKeyHelp')}
+        </p>
+
+        {showForm ? (
+          <div className="mt-2 flex items-center gap-2">
+            <div className="relative flex-1">
+              <input
+                type={showKey ? 'text' : 'password'}
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder={t('ghlSection.apiKeyPlaceholder')}
+                className="w-full bg-bg-surface border border-border-subtle rounded-md px-3 py-2 pr-10 text-sm font-mono text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-accent/50"
+                autoComplete="off"
+                spellCheck={false}
+              />
+              <button
+                type="button"
+                onClick={() => setShowKey((v) => !v)}
+                aria-label={showKey ? t('ghlSection.hideKey') : t('ghlSection.showKey')}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-text-tertiary hover:text-text-secondary"
+              >
+                {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
+              </button>
+            </div>
+            {configured && (
+              <button
+                type="button"
+                onClick={() => { setEditing(false); setApiKey(''); }}
+                className="px-3 py-2 text-sm rounded-md font-medium text-text-tertiary hover:text-text-secondary"
+              >
+                {t('common.cancel')}
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="mt-2 flex items-center gap-2">
+            <div className="flex-1 flex items-center gap-2 px-3 py-2 rounded-md bg-bg-surface border border-border-subtle text-sm">
+              <span className="text-text-secondary font-mono">••••••••••••••••</span>
+            </div>
+            <button
+              type="button"
+              onClick={() => { setEditing(true); setTestState({ kind: 'idle' }); }}
+              className="px-3 py-2 text-sm rounded-md font-medium bg-accent/15 text-accent hover:bg-accent/25"
+            >
+              {t('ghlSection.replaceKey')}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Location ID */}
+      <div>
+        <label className="text-xs font-medium text-text-secondary">{t('ghlSection.locationIdLabel')}</label>
+        <p className="text-[11px] text-text-tertiary mt-1 leading-relaxed">
+          {t('ghlSection.locationIdHelp')}
+        </p>
+        <input
+          type="text"
+          value={locationId}
+          onChange={(e) => setLocationId(e.target.value)}
+          placeholder={t('ghlSection.locationIdPlaceholder')}
+          disabled={configured && !editing}
+          className="mt-2 w-full bg-bg-surface border border-border-subtle rounded-md px-3 py-2 text-sm font-mono text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-accent/50 disabled:opacity-60 disabled:cursor-not-allowed"
+          spellCheck={false}
+        />
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-between pt-1">
+        <div className="flex items-center gap-2">
+          {configured && !editing && (
+            <>
+              <button
+                type="button"
+                onClick={handleTest}
+                disabled={testState.kind === 'testing'}
+                className={clsx(
+                  'px-3 py-1.5 text-xs rounded-md font-medium transition-colors',
+                  'bg-accent/15 text-accent hover:bg-accent/25',
+                  'disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5',
+                )}
+              >
+                {testState.kind === 'testing' && <Loader2 size={11} className="animate-spin" />}
+                {t('ghlSection.testConnection')}
+              </button>
+              <button
+                type="button"
+                onClick={handleDisconnect}
+                className="px-3 py-1.5 text-xs rounded-md font-medium text-text-tertiary hover:text-red-400 transition-colors"
+              >
+                {t('ghlSection.disconnect')}
+              </button>
+            </>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3">
+          {savedFlash && (
+            <span className="text-xs text-emerald-400 flex items-center gap-1.5">
+              <CheckCircle2 size={12} /> {t('ghlSection.saved')}
+            </span>
+          )}
+          {showForm && (
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={!apiKey.trim() || !locationId.trim()}
+              className="px-3 py-1.5 text-xs rounded-md font-medium bg-accent text-white hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {t('common.save')}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Test result */}
+      {testState.kind === 'ok' && (
+        <div className="flex items-center gap-1.5 text-xs text-emerald-400">
+          <CheckCircle2 size={13} />
+          <span>{t('ghlSection.testSuccess')}</span>
+        </div>
+      )}
+      {testState.kind === 'err' && (
+        <div className="flex items-center gap-1.5 text-xs text-red-400">
+          <XCircle size={13} />
+          <span>{testState.error}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -890,6 +890,26 @@ const en = {
     notionDesc: 'Pages, databases, and knowledge base',
     slack: 'Slack',
     slackDesc: 'Team messaging and notifications',
+    ghl: 'GoHighLevel',
+    ghlDesc: 'Sync contacts and push intel briefs to your GHL CRM.',
+  },
+
+  // ── GoHighLevel section ─────────────────────────────────────
+  ghlSection: {
+    apiKeyLabel: 'API Key',
+    apiKeyHelp: 'Your GoHighLevel Private Integration API key. Found in Settings → Integrations → API Keys.',
+    apiKeyPlaceholder: 'ey…',
+    showKey: 'Show API key',
+    hideKey: 'Hide API key',
+    replaceKey: 'Replace key',
+    locationIdLabel: 'Location ID',
+    locationIdHelp: 'The sub-account (location) ID to sync contacts into. Found in your GHL location URL.',
+    locationIdPlaceholder: 'abc123…',
+    testConnection: 'Test connection',
+    disconnect: 'Disconnect',
+    saved: 'Saved',
+    testSuccess: 'Connection successful — GHL is reachable.',
+    testFailed: 'Connection test failed.',
   },
 
   // ── Channels section ────────────────────────────────────────

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -884,7 +884,27 @@ const es: TranslationKeys = {
     notion: 'Notion',
     notionDesc: 'P\u00e1ginas, bases de datos y base de conocimiento',
     slack: 'Slack',
-    slackDesc: 'Mensajer\u00eda de equipo y notificaciones',
+    slackDesc: 'Mensajería de equipo y notificaciones',
+    ghl: 'GoHighLevel',
+    ghlDesc: 'Sincroniza contactos y envía informes de inteligencia a tu CRM de GHL.',
+  },
+
+  // ── Sección de GoHighLevel ──────────────────────────────────
+  ghlSection: {
+    apiKeyLabel: 'Clave API',
+    apiKeyHelp: 'Tu clave de API de integración privada de GoHighLevel. Se encuentra en Configuración → Integraciones → Claves de API.',
+    apiKeyPlaceholder: 'ey…',
+    showKey: 'Mostrar clave API',
+    hideKey: 'Ocultar clave API',
+    replaceKey: 'Reemplazar clave',
+    locationIdLabel: 'ID de ubicación',
+    locationIdHelp: 'El ID de la subcuenta (ubicación) donde sincronizar los contactos. Encuéntralo en la URL de tu ubicación en GHL.',
+    locationIdPlaceholder: 'abc123…',
+    testConnection: 'Probar conexión',
+    disconnect: 'Desconectar',
+    saved: 'Guardado',
+    testSuccess: 'Conexión exitosa — GHL está accesible.',
+    testFailed: 'La prueba de conexión falló.',
   },
 
   // ── Secci\u00f3n de canales ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds a generic **outbound integrations package** (`backend/integrations/`) following the existing subpackage pattern — GHL is the first integration, others can add HubSpot, Salesforce, etc.
- When the **Sales Intel Analyst** expert completes a task, Cerebro automatically pushes the practice name as a GHL contact (finds existing or creates new with a `cerebro-brief` tag) and attaches the full intel brief as a note
- Credentials (`ghl_api_key`, `ghl_location_id`) stored in the existing **Settings table** — no schema migration needed
- **GHL failures are silent**: all errors are logged but never propagate — a misconfigured key cannot break task completion
- `httpx` was already in requirements.txt; no new dependencies

## Architecture notes

- **Fire-and-forget via `asyncio.create_task`**: GHL push is dispatched after the DB commit so the Electron runtime gets its response immediately
- **Lazy import of `GHLClient`**: if someone runs Cerebro without the integrations package, only the push degrades — startup is unaffected
- **`find_or_create_contact` is idempotent**: running the same practice through the analyst twice won't create duplicate GHL contacts

## Test plan

- [ ] Configure GHL credentials via `PUT /integrations/ghl/config`
- [ ] Verify `GET /integrations/ghl/config` returns `api_key_set: true` without exposing the key
- [ ] Run `POST /integrations/ghl/test` — should return `{"ok": true}`
- [ ] Trigger a Sales Intel Analyst task, confirm contact + note appear in GHL after completion
- [ ] Confirm task moves to `to_review` even when GHL credentials are invalid
- [ ] Confirm tasks from other experts do NOT trigger GHL push