### PR TITLE
fix: run_command reports a timed-out command as a successful step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ build/Release
 
 # Dependency directories
 node_modules/
+node_modules
 jspm_packages/
 
 # TypeScript v1 declaration files

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/clover/Desktop/projects/Cerebro/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/clover/Desktop/projects/Cerebro/node_modules

--- a/src/engine/__tests__/run-command.test.ts
+++ b/src/engine/__tests__/run-command.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { runCommandAction } from '../actions/run-command';
 import { RunScratchpad } from '../scratchpad';
 import type { ActionContext } from '../actions/types';
@@ -61,6 +64,24 @@ describe('runCommandAction', () => {
         context: makeContext(),
       }),
     ).rejects.toThrow('Command failed');
+  });
+
+  it('rejects when the command exceeds its timeout', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cerebro-run-command-timeout-'));
+    writeFileSync(join(dir, 'Makefile'), 'slow:\n\t@sleep 2\n');
+
+    try {
+      await expect(
+        runCommandAction.execute({
+          params: { command: 'make', args: 'slow', working_directory: dir, timeout: 0.1 },
+          wiredInputs: {},
+          scratchpad: new RunScratchpad(),
+          context: makeContext(),
+        }),
+      ).rejects.toThrow(/timed out|timeout/i);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('rejects non-existent working directory', async () => {

--- a/src/engine/actions/run-command.ts
+++ b/src/engine/actions/run-command.ts
@@ -21,6 +21,12 @@ interface RunCommandParams {
   env?: Record<string, string>;
 }
 
+interface ExecFileFailure extends Error {
+  code?: number | string | null;
+  killed?: boolean;
+  signal?: NodeJS.Signals | null;
+}
+
 const ALLOWED_COMMANDS_SET = new Set(ALLOWED_COMMANDS);
 
 const BLOCKED_ENV_KEYS = new Set([
@@ -154,9 +160,6 @@ export const runCommandAction: ActionDefinition = {
         (error, stdout, stderr) => {
           removeAbortListener();
           const durationMs = Date.now() - startTime;
-          const exitCode = error?.code
-            ? (typeof error.code === 'number' ? error.code : 1)
-            : 0;
 
           // Log stdout lines
           if (stdout) {
@@ -169,8 +172,19 @@ export const runCommandAction: ActionDefinition = {
             }
           }
 
-          if (exitCode !== 0) {
-            const errMsg = stderr || error?.message || `Exit code ${exitCode}`;
+          if (error) {
+            const execError = error as ExecFileFailure;
+            const exitCode = typeof execError.code === 'number' ? execError.code : 1;
+
+            if (execError.signal) {
+              const message = execError.killed
+                ? `Command timed out after ${timeoutMs}ms`
+                : `Command terminated by signal ${execError.signal}`;
+              reject(new Error(message));
+              return;
+            }
+
+            const errMsg = stderr || error.message || `Exit code ${exitCode}`;
             reject(new Error(`Command failed (exit ${exitCode}): ${errMsg.slice(0, 200)}`));
             return;
           }
@@ -179,7 +193,7 @@ export const runCommandAction: ActionDefinition = {
             data: {
               stdout: stdout || '',
               stderr: stderr || '',
-              exit_code: exitCode,
+              exit_code: 0,
               duration_ms: durationMs,
             },
             summary: `${command} completed (${durationMs}ms)`,


### PR DESCRIPTION
Fixes #24.

## Summary

A `run_command` step that timed out could still be recorded as successful with `exit_code: 0`. That let downstream routine steps run on incomplete command output instead of failing the routine.

## Root cause

In `src/engine/actions/run-command.ts`, `runCommandAction.execute` derived `exitCode` with `error?.code ? ... : 0`. Node's `execFile` timeout and signal-kill errors can have `code: null` and `signal: 'SIGTERM'`, so the timeout branch fell through to the success resolver. The action only rejected when the computed exit code was nonzero, which missed signal-based failures.

## Fix

- Add `ExecFileFailure` handling in `src/engine/actions/run-command.ts` so any `execFile` error rejects instead of resolving.
- Return a readable timeout error from `runCommandAction.execute` when Node reports the child was killed by timeout.
- Keep nonzero exit failures on the existing `Command failed (exit N)` path.

## Test plan

New tests cover:
- `rejects when the command exceeds its timeout` — Creates a temporary Makefile target that sleeps past the configured timeout and asserts `run_command` rejects with a timeout error.

Manual verification: Ran `npx vitest run src/engine/__tests__/run-command.test.ts`: 20 tests passed. Ran `npx vitest run`; the targeted suite passed, but the full run failed on unrelated sandbox `listen EPERM: operation not permitted 127.0.0.1` failures in tests that start local servers. Ran the filtered TypeScript check; it produced no `src/` diagnostics.

## Notes

- Could not create the required local commits because `git add` fails with `fatal: Unable to create '/Users/clover/Desktop/projects/Cerebro/.git/worktrees/01KT0R6SK93KAQ8BQTAJB81ZAW/index.lock': Operation not permitted`. The `.git` link itself is also immutable in this sandbox, so a local metadata workaround was blocked.

---

_Co-authored by [Obelisk](https://github.com/HackerHouse-io/Obelisk)_ · _Reply `/obelisk explain` for the full reasoning trace._