### PR TITLE
fix: Claude auth recovery card still shows the raw error text

### DIFF
--- a/src/__tests__/chat-helpers.test.ts
+++ b/src/__tests__/chat-helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   generateId,
   titleFromContent,
+  buildAgentErrorContent,
   fromApiConversation,
   fromApiMessage,
   toApiProposal,
@@ -52,6 +53,33 @@ describe('titleFromContent', () => {
     const result = titleFromContent(long);
     expect(result).toBe('A'.repeat(40) + '...');
     expect(result.length).toBe(43);
+  });
+});
+
+describe('buildAgentErrorContent', () => {
+  const AUTH_ERROR = 'run claude in a terminal to sign in';
+
+  it('embeds the raw error for ordinary failures (no partial text)', () => {
+    expect(buildAgentErrorContent('', 'boom', 'unknown')).toBe('Error: boom');
+  });
+
+  it('keeps partial text above the error for ordinary failures', () => {
+    expect(buildAgentErrorContent('hello', 'boom', 'unknown')).toBe(
+      'hello\n\n---\n_Error: boom_',
+    );
+  });
+
+  it('never writes the raw auth error into the body (the recovery card replaces it)', () => {
+    const content = buildAgentErrorContent('', AUTH_ERROR, 'auth');
+    expect(content).toBe('');
+    expect(content).not.toContain(AUTH_ERROR);
+    expect(content).not.toContain('Error:');
+  });
+
+  it('preserves only the partial prose for auth failures, dropping the raw error', () => {
+    const content = buildAgentErrorContent('Here is what I found', AUTH_ERROR, 'auth');
+    expect(content).toBe('Here is what I found');
+    expect(content).not.toContain(AUTH_ERROR);
   });
 });
 

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -80,14 +80,17 @@ export default function ChatMessage({ message, nodeRef }: ChatMessageProps) {
   }, [isUser, message.content]);
 
   // The auth-recovery card replaces the "Error: ..." prose entirely —
-  // showing both would duplicate the message and look broken.
+  // showing both would duplicate the message and look broken. Suppressing
+  // also covers the copy action below: the raw CLI auth string (e.g.
+  // "run claude in a terminal to sign in") must never reach the clipboard,
+  // the recovery card is the whole message now.
   const suppressContent = !isUser && message.errorClass === 'auth';
   const hasContent = !suppressContent && displayContent.length > 0;
   const assistantBusy =
     !isUser && (message.isThinking || message.isStreaming === true) && !hasContent;
 
   const { copied, copy } = useCopyMessage();
-  const canCopy = copyableMarkdown.length > 0 && !message.isStreaming;
+  const canCopy = !suppressContent && copyableMarkdown.length > 0 && !message.isStreaming;
 
   // Long assistant messages (generated documents, lengthy prose) get a
   // top-of-bubble toolbar + collapse toggle. Pure-text length is a coarse

--- a/src/components/chat/__tests__/ChatMessage-auth-recovery.test.tsx
+++ b/src/components/chat/__tests__/ChatMessage-auth-recovery.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Regression test for issue #23 — "Claude auth recovery card still shows the
+ * raw error text".
+ *
+ * When an agent run ends with `errorClass: 'auth'`, the assistant bubble must
+ * render ONLY the Claude Code login recovery card. The raw CLI error string
+ * (e.g. "run claude in a terminal to sign in") that ChatContext stores in the
+ * message content must never be visible — the recovery UI replaces it.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import '../../../i18n';
+import ChatMessage from '../ChatMessage';
+import { ToastProvider } from '../../../context/ToastContext';
+import type { Message } from '../../../types/chat';
+
+// ChatMessage and ClaudeCodeLoginCard both call useChat(); stub it so we don't
+// have to stand up the whole ChatProvider for a pure-render assertion.
+vi.mock('../../../context/ChatContext', () => ({
+  useChat: () => ({
+    isStreaming: false,
+    conversations: [],
+    regenerateFromUserMessage: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  // The login card subscribes to the claudeCode login bridge on mount.
+  (window as unknown as { cerebro: unknown }).cerebro = {
+    claudeCode: {
+      login: { onEvent: vi.fn(() => () => undefined) },
+    },
+  };
+});
+
+afterEach(() => cleanup());
+
+describe('ChatMessage auth recovery', () => {
+  it('hides raw auth error content when rendering Claude login recovery', () => {
+    const message: Message = {
+      id: 'm1',
+      conversationId: 'c1',
+      role: 'assistant',
+      content: 'Error: run claude in a terminal to sign in',
+      createdAt: new Date(),
+      errorClass: 'auth',
+    };
+
+    render(
+      <ToastProvider>
+        <ChatMessage message={message} />
+      </ToastProvider>,
+    );
+
+    // The recovery card is shown…
+    expect(screen.getByText(/sign in to claude/i)).toBeInTheDocument();
+    // …and the raw error string is NOT.
+    expect(screen.queryByText(/run claude in a terminal/i)).not.toBeInTheDocument();
+  });
+
+  it('does not expose the raw auth error via the copy action', () => {
+    const message: Message = {
+      id: 'm1',
+      conversationId: 'c1',
+      role: 'assistant',
+      content: 'Error: run claude in a terminal to sign in',
+      createdAt: new Date(),
+      errorClass: 'auth',
+    };
+
+    render(
+      <ToastProvider>
+        <ChatMessage message={message} />
+      </ToastProvider>,
+    );
+
+    // The recovery card replaces the bubble entirely — there is nothing
+    // meaningful to copy, so no copy button (which would otherwise put the
+    // raw "Error: run claude…" string on the clipboard) should render.
+    expect(screen.queryByLabelText(/copy message/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -27,6 +27,7 @@ import type { DAGDefinition } from '../engine/dag/types';
 import {
   generateId,
   titleFromContent,
+  buildAgentErrorContent,
   isUntitledConversationTitle,
   fromApiConversation,
   toApiProposal,
@@ -858,9 +859,11 @@ export function ChatProvider({ children }: { children: ReactNode }) {
                 // lose what the agent already produced — append the error
                 // below a separator instead of overwriting the body.
                 const partial = state.accumulated.trim();
-                const content = partial
-                  ? `${partial}\n\n---\n_Error: ${event.error}_`
-                  : `Error: ${event.error}`;
+                const content = buildAgentErrorContent(
+                  partial,
+                  event.error,
+                  event.errorClass,
+                );
                 updateMessage(convId, assistantId, {
                   content,
                   isThinking: false,

--- a/src/context/chat-helpers.ts
+++ b/src/context/chat-helpers.ts
@@ -1,6 +1,7 @@
 import type {
   Conversation,
   Message,
+  MessageErrorClass,
   RoutineProposal,
   ExpertProposal,
   TeamProposal,
@@ -12,6 +13,29 @@ import type {
 
 export function generateId(): string {
   return crypto.randomUUID().replace(/-/g, '');
+}
+
+/**
+ * Build the assistant message body for a run that ended in error.
+ *
+ * Normally we surface the raw CLI error so the user sees what went wrong,
+ * preserving any partial streamed text above a separator. Auth failures are
+ * the exception: they're fully handled by the in-app Claude Code login
+ * recovery card, which replaces the message body. The raw auth string (e.g.
+ * "run claude in a terminal to sign in") must never be written into the
+ * content — it's the very text the recovery UI exists to hide, and storing it
+ * lets it leak through the copy action or any render path that loses
+ * `errorClass`. For auth we keep only the partial prose (usually empty).
+ */
+export function buildAgentErrorContent(
+  partial: string,
+  error: string,
+  errorClass?: MessageErrorClass,
+): string {
+  if (errorClass === 'auth') {
+    return partial;
+  }
+  return partial ? `${partial}\n\n---\n_Error: ${error}_` : `Error: ${error}`;
 }
 
 export function titleFromContent(content: string): string {


### PR DESCRIPTION
Fixes #23.

## Summary

When a chat run failed with a Claude auth error, the assistant bubble is supposed to be fully replaced by the in-app 'Sign in to Claude' recovery card with no raw CLI error text shown. The card's display suppression already shipped, but the raw auth string (e.g. 'run claude in a terminal to sign in') was still stored in the message body and exposed through the message's copy action — so the text the recovery UI exists to hide could still reach the user. This fix removes the raw auth text at its source and disables the copy action on recovery messages.

## Root cause

In src/context/ChatContext.tsx the 'error' event handler unconditionally built the assistant body as `Error: ${event.error}` (or appended it under a separator when partial text existed), including for `errorClass === 'auth'`. ChatMessage.tsx hides that body from the bubble via `suppressContent`, but `copyableMarkdown` is still derived from `message.content`, so `canCopy` stayed true and the copy button put the raw auth string on the clipboard. The raw text was thus retained in the data model and leaked through any path that reads content rather than gating on errorClass.

## Fix

- Add a pure `buildAgentErrorContent(partial, error, errorClass)` helper in src/context/chat-helpers.ts that returns only the partial prose (never the raw error) when errorClass is 'auth', and keeps the existing 'Error: …' formatting for all other classes.
- Wire ChatContext.tsx's error handler to use buildAgentErrorContent instead of inlining the raw `Error: ${event.error}` string, so auth failures never persist the raw CLI text into message.content.
- Gate `canCopy` on `!suppressContent` in src/components/chat/ChatMessage.tsx so auth-recovery messages render no copy button and the raw auth string can never reach the clipboard, even for legacy stored content.

## Test plan

New `src/components/chat/__tests__/ChatMessage-auth-recovery.test.tsx` covers:
- `hides raw auth error content when rendering Claude login recovery` — The recovery card ('Sign in to Claude') renders and the raw 'run claude in a terminal' string is not in the document.
- `does not expose the raw auth error via the copy action` — No 'Copy message' button renders for an auth-recovery message, so the raw error cannot be copied to the clipboard.
- `never writes the raw auth error into the body (the recovery card replaces it)` — buildAgentErrorContent('', authError, 'auth') returns '' and contains neither the raw error nor 'Error:'.
- `preserves only the partial prose for auth failures, dropping the raw error` — buildAgentErrorContent(partial, authError, 'auth') returns just the partial text, dropping the raw error.
- `embeds the raw error for ordinary failures (no partial text)` — Non-auth errors still produce 'Error: boom' so normal failures stay visible.
- `keeps partial text above the error for ordinary failures` — Non-auth errors with partial text keep the 'partial\n\n---\n_Error: …_' format.

Manual verification: Ran the full vitest suite (1112 passed, 17 skipped, 0 regressions) and `npx tsc --noEmit` (no type errors in ChatContext, chat-helpers, or ChatMessage). The new copy-action test was confirmed red before the ChatMessage change and green after.

## Notes

- The display-suppression half of this issue (the bubble itself hiding the raw text) already shipped in commit 047830f via `suppressContent`; the regression test confirms it and guards against re-introduction. The remaining, still-reproducible leak was the stored content + copy action, which this PR fixes at the source. A Playwright screenshot was not used because the recovery card only appears after a live Claude Code auth failure inside the Electron shell — the automated UI test reproduces and proves the fix without that flow.

## Evidence

### Tests
- `patch` — 8875 bytes · sha256:f7e46d5dedee · captured in the run audit log
- `failing_test_diff` — 8875 bytes · sha256:f7e46d5dedee · captured in the run audit log
- `test_output` — 33 bytes · sha256:94ba302f9610 · captured in the run audit log
- `test_output` — 154 bytes · sha256:d10e4994cf40 · captured in the run audit log

### Screenshots
_Verified by an automated UI test — see the Test plan below._

### Logs
_(not applicable — no backend changes in this PR)_

### Reasoning
See the reasoning in this PR and the linked audit log.

---

_Co-authored by [Obelisk](https://github.com/HackerHouse-io/Obelisk)_ · _Reply `/obelisk explain` for the full reasoning trace._