### PR TITLE
fix: Sidebar Chat nav reopens the stale active conversation

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -271,9 +271,11 @@ export default function Sidebar() {
 
   const handleNavClick = (screen: Screen) => {
     setActiveScreen(screen);
-    if (screen !== 'chat') {
-      setActiveConversation(null);
-    }
+    // Always clear the active conversation on nav — including when returning to
+    // Chat — so the sidebar lands on the welcome/input state instead of
+    // reopening the previously selected thread. Selecting a conversation from
+    // the history list re-sets it explicitly.
+    setActiveConversation(null);
   };
 
   const handleDelete = (e: React.MouseEvent, id: string) => {

--- a/src/components/layout/__tests__/Sidebar-chat-nav.test.tsx
+++ b/src/components/layout/__tests__/Sidebar-chat-nav.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Regression test for issue #17 — "Sidebar Chat nav reopens the stale active
+ * conversation".
+ *
+ * Navigating Chat -> Routines -> Chat through the sidebar must clear the active
+ * conversation so the Chat surface falls back to the welcome/input state until a
+ * conversation is explicitly selected. The bug was that the nav handler skipped
+ * clearing whenever the destination was `chat`, so the previous thread stayed
+ * active and AppLayout re-rendered its message list.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+const setActiveConversation = vi.fn();
+const setActiveScreen = vi.fn();
+
+vi.mock('../../../context/ChatContext', () => ({
+  useChat: () => ({
+    generalConversations: [],
+    activeConversationId: 'conv-1',
+    activeScreen: 'routines',
+    isLoading: false,
+    startNewChat: vi.fn(),
+    setActiveConversation,
+    setActiveScreen,
+    renameConversation: vi.fn(),
+    deleteConversation: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../context/ApprovalContext', () => ({
+  useApprovals: () => ({ pendingCount: 0 }),
+}));
+
+vi.mock('../../../context/TaskContext', () => ({
+  useTasks: () => ({ stats: { in_progress: 0, to_review: 0 } }),
+}));
+
+vi.mock('../../../context/OnboardingContext', () => ({
+  useOnboarding: () => ({ spotlightedNavId: null }),
+}));
+
+import Sidebar from '../Sidebar';
+
+describe('Sidebar — Chat nav clears the active conversation', () => {
+  beforeEach(() => {
+    setActiveConversation.mockClear();
+    setActiveScreen.mockClear();
+  });
+
+  it('clears the active conversation when the Chat nav item is clicked', () => {
+    render(<Sidebar />);
+
+    // The Chat nav label resolves to its i18n key via the mocked t().
+    fireEvent.click(screen.getByText('nav.chat'));
+
+    expect(setActiveScreen).toHaveBeenCalledWith('chat');
+    // The previous thread must be cleared so the welcome state shows.
+    expect(setActiveConversation).toHaveBeenCalledWith(null);
+
+    cleanup();
+  });
+});


### PR DESCRIPTION
Fixes #17.

## Summary

Clicking the Chat nav item in the sidebar after visiting another screen (e.g. Chat → Routines → Chat) used to reopen the previously active conversation instead of showing the welcome/input state. The active thread stayed selected, so users were dropped back into a stale conversation they had navigated away from. Now any sidebar navigation — including returning to Chat — lands on the empty welcome state until a conversation is explicitly chosen from the history list.

## Root cause

In `src/components/layout/Sidebar.tsx`, `handleNavClick` only called `setActiveConversation(null)` when the destination screen was not `chat` (the `if (screen !== 'chat')` guard). Because `AppLayout.renderContent()` renders `<ChatView>` whenever `activeConversation` is still set and only falls back to `<WelcomeView>` when it is null, returning to Chat with a lingering `activeConversationId` re-rendered the old thread's message list.

## Fix

- Remove the `screen !== 'chat'` guard in `handleNavClick` (`src/components/layout/Sidebar.tsx`) so the active conversation is cleared on every sidebar navigation, including back to Chat; selecting a conversation from the history list still sets it explicitly via `setActiveConversation(conv.id)`.

## Test plan

New `src/components/layout/__tests__/Sidebar-chat-nav.test.tsx` covers:
- `clears the active conversation when the Chat nav item is clicked` — Rendering Sidebar with an active conversation and clicking the Chat nav button calls setActiveScreen('chat') and setActiveConversation(null).

Manual verification: Ran `npx vitest run` — the new test fails before the fix and passes after; full suite is 1113 passed / 17 skipped with no regressions.

## Evidence

### Tests
- `patch` — 3258 bytes · sha256:41b6b24aa50a · captured in the run audit log
- `failing_test_diff` — 3258 bytes · sha256:41b6b24aa50a · captured in the run audit log
- `test_output` — 33 bytes · sha256:94ba302f9610 · captured in the run audit log
- `test_output` — 133 bytes · sha256:6f6c0883dd8a · captured in the run audit log

### Screenshots
_Verified by an automated UI test — see the Test plan below._

### Logs
_(not applicable — no backend changes in this PR)_

### Reasoning
See the reasoning in this PR and the linked audit log.

---

_Co-authored by [Obelisk](https://github.com/HackerHouse-io/Obelisk)_ · _Reply `/obelisk explain` for the full reasoning trace._