### PR TITLE
fix: Codex chat is blocked when Claude Code is not installed

### DIFF
--- a/src/context/ChatContext.engine-gate.test.tsx
+++ b/src/context/ChatContext.engine-gate.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { ChatProvider, useChat } from './ChatContext';
+import type { ClaudeCodeInfo } from '../types/providers';
+import type { EngineId } from '../engines/types';
+
+// ── Controllable mocks for the sibling contexts ChatProvider consumes ──
+let mockClaudeCodeInfo: ClaudeCodeInfo = { status: 'available' };
+let mockCodexInfo: ClaudeCodeInfo = { status: 'available' };
+let mockDefaultEngine: EngineId = 'claude-code';
+
+vi.mock('./ProviderContext', () => ({
+  useProviders: () => ({
+    claudeCodeInfo: mockClaudeCodeInfo,
+    codexInfo: mockCodexInfo,
+    refreshClaudeCodeStatus: vi.fn(),
+    refreshCodexStatus: vi.fn(),
+  }),
+}));
+
+vi.mock('./EngineContext', () => ({
+  useEngine: () => ({
+    defaultEngine: mockDefaultEngine,
+    setDefaultEngine: vi.fn(),
+    // New conversations resolve the app-wide default engine.
+    engineForConversation: () => mockDefaultEngine,
+    setConversationEngine: vi.fn(),
+  }),
+}));
+
+vi.mock('./QualityContext', () => ({
+  useQualityTier: () => ({
+    tier: 'balanced',
+    setTier: vi.fn(),
+    model: 'sonnet',
+    setModel: vi.fn(),
+  }),
+}));
+
+vi.mock('./RoutineContext', () => ({
+  useRoutines: () => ({
+    registerRunCallback: vi.fn(() => vi.fn()),
+  }),
+}));
+
+// Minimal window.cerebro surface ChatProvider touches during mount + send.
+const agentRun = vi.fn().mockResolvedValue('run-1');
+const agentOnEvent = vi.fn(() => vi.fn());
+
+function installCerebroMock() {
+  (window as unknown as { cerebro: unknown }).cerebro = {
+    getStatus: vi.fn().mockResolvedValue('healthy'),
+    invoke: vi.fn().mockResolvedValue({ ok: true, data: { conversations: [] } }),
+    agent: { run: agentRun, onEvent: agentOnEvent, cancel: vi.fn() },
+    telegram: { onConversationUpdated: vi.fn(() => vi.fn()) },
+    chatActions: {
+      generateTitle: vi.fn().mockResolvedValue(null),
+      onTeamRunAnnounced: vi.fn(() => vi.fn()),
+      onTeamMemberUpdate: vi.fn(() => vi.fn()),
+      onIntegrationProposal: vi.fn(() => vi.fn()),
+    },
+    claudeCode: { probeAuth: vi.fn().mockResolvedValue(undefined) },
+    engine: vi.fn(() => vi.fn()),
+  };
+}
+
+// Test harness: renders the provider and exposes sendMessage + chatError.
+let sendRef: (content: string) => void;
+let errorTitle: string | null;
+
+function Harness() {
+  const { sendMessage, chatError } = useChat();
+  sendRef = sendMessage;
+  errorTitle = chatError?.title ?? null;
+  return <div data-testid="error">{chatError?.title ?? 'no-error'}</div>;
+}
+
+function renderChat(): void {
+  render(
+    (
+      <ChatProvider>
+        <Harness />
+      </ChatProvider>
+    ) as ReactNode,
+  );
+}
+
+beforeEach(() => {
+  agentRun.mockClear();
+  agentOnEvent.mockClear();
+  mockClaudeCodeInfo = { status: 'available' };
+  mockCodexInfo = { status: 'available' };
+  mockDefaultEngine = 'claude-code';
+  installCerebroMock();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ChatContext engine availability gate', () => {
+  it('allows Codex chat when Claude Code is missing', async () => {
+    mockClaudeCodeInfo = { status: 'unavailable' };
+    mockCodexInfo = { status: 'available' };
+    mockDefaultEngine = 'codex';
+
+    renderChat();
+
+    await act(async () => {
+      sendRef('hello');
+    });
+
+    // Bug: previously the Claude-Code-not-detected modal blocked the send.
+    expect(errorTitle).not.toBe('Claude Code not detected');
+    expect(screen.getByTestId('error').textContent).toBe('no-error');
+    expect(agentRun).toHaveBeenCalledWith(
+      expect.objectContaining({ engine: 'codex' }),
+    );
+  });
+
+  it('still blocks Claude Code chat when Claude Code is missing', async () => {
+    mockClaudeCodeInfo = { status: 'unavailable' };
+    mockCodexInfo = { status: 'available' };
+    mockDefaultEngine = 'claude-code';
+
+    renderChat();
+
+    await act(async () => {
+      sendRef('hello');
+    });
+
+    expect(errorTitle).toBe('Claude Code not detected');
+    expect(agentRun).not.toHaveBeenCalled();
+  });
+
+  it('blocks Codex chat when Codex is missing', async () => {
+    mockClaudeCodeInfo = { status: 'available' };
+    mockCodexInfo = { status: 'unavailable' };
+    mockDefaultEngine = 'codex';
+
+    renderChat();
+
+    await act(async () => {
+      sendRef('hello');
+    });
+
+    expect(errorTitle).toBe('Codex not detected');
+    expect(agentRun).not.toHaveBeenCalled();
+  });
+});

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -155,7 +155,7 @@ function sweepOpenMembers(
 }
 
 export function ChatProvider({ children }: { children: ReactNode }) {
-  const { claudeCodeInfo } = useProviders();
+  const { claudeCodeInfo, codexInfo } = useProviders();
   const { registerRunCallback } = useRoutines();
   const { tier: qualityTier, model: responseModel } = useQualityTier();
   const qualityTierRef = useRef(qualityTier);
@@ -196,6 +196,39 @@ export function ChatProvider({ children }: { children: ReactNode }) {
 
   const claudeCodeInfoRef = useRef(claudeCodeInfo);
   claudeCodeInfoRef.current = claudeCodeInfo;
+  const codexInfoRef = useRef(codexInfo);
+  codexInfoRef.current = codexInfo;
+
+  // Gate sending on the *selected* engine's availability — not always Claude
+  // Code. When Codex is the active engine, a missing Claude Code install must
+  // not block the run. Returns a ChatError to surface, or null when the engine
+  // for `conversationId` is available.
+  const engineUnavailableError = useCallback(
+    (conversationId: string | null | undefined): ChatError | null => {
+      const engine = engineForConversationRef.current(conversationId);
+      if (engine === 'codex') {
+        if (codexInfoRef.current.status !== 'available') {
+          return {
+            title: 'Codex not detected',
+            message:
+              'Cerebro is set to use the Codex CLI as its engine. Install it and re-detect from Integrations.',
+            navigateTo: 'integrations',
+          };
+        }
+        return null;
+      }
+      if (claudeCodeInfoRef.current.status !== 'available') {
+        return {
+          title: 'Claude Code not detected',
+          message:
+            'Cerebro uses the Claude Code CLI as its engine. Install it and re-detect from Integrations.',
+          navigateTo: 'integrations',
+        };
+      }
+      return null;
+    },
+    [],
+  );
 
   // Tracks conversations whose title is still owned by the auto-titler.
   // Inserted when a new conversation is created from sendMessage(); removed
@@ -916,14 +949,12 @@ export function ChatProvider({ children }: { children: ReactNode }) {
 
   const sendMessage = useCallback(
     (content: string) => {
-      // ── Guard: require Claude Code to be detected ──
-      if (claudeCodeInfoRef.current.status !== 'available') {
-        setChatError({
-          title: 'Claude Code not detected',
-          message:
-            'Cerebro uses the Claude Code CLI as its engine. Install it and re-detect from Integrations.',
-          navigateTo: 'integrations',
-        });
+      // ── Guard: require the *selected* engine to be detected ──
+      // A new conversation inherits the app-wide default engine, so resolve
+      // against the active conversation (null → default) before any run.
+      const engineError = engineUnavailableError(activeConversationId);
+      if (engineError) {
+        setChatError(engineError);
         return;
       }
 
@@ -984,6 +1015,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       addMessage,
       runAgentForMessage,
       runAutoTitle,
+      engineUnavailableError,
     ],
   );
 
@@ -1039,13 +1071,9 @@ export function ChatProvider({ children }: { children: ReactNode }) {
 
   const regenerateFromUserMessage = useCallback(
     async (messageId: string, newContent?: string) => {
-      if (claudeCodeInfoRef.current.status !== 'available') {
-        setChatError({
-          title: 'Claude Code not detected',
-          message:
-            'Cerebro uses the Claude Code CLI as its engine. Install it and re-detect from Integrations.',
-          navigateTo: 'integrations',
-        });
+      const engineError = engineUnavailableError(activeConversationIdRef.current);
+      if (engineError) {
+        setChatError(engineError);
         return;
       }
       if (isStreamingRef.current) return;
@@ -1113,7 +1141,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
 
       runAgentForMessage(convId, assistantId, trimmed, expertId);
     },
-    [chainWrite, runAgentForMessage],
+    [chainWrite, runAgentForMessage, engineUnavailableError],
   );
 
   // ── Run routine from UI (triggered via "Run Now" button) ────────


### PR DESCRIPTION
Fixes #22.

## Summary

When a user selected Codex as the active chat engine but did not have the Claude Code CLI installed, pressing Enter in Chat showed the 'Claude Code not detected' modal and started no run. The send path always demanded Claude Code regardless of which engine was selected, so Codex-only users couldn't chat at all even though Codex was installed and signed in. After the fix, sending with Codex selected starts an agent run with engine: 'codex' even when Claude Code is missing.

## Root cause

In src/context/ChatContext.tsx, both sendMessage and regenerateFromUserMessage opened with an unconditional guard `if (claudeCodeInfoRef.current.status !== 'available')` that returned early with the Claude-Code-not-detected error before the selected engine was ever consulted. The resolved engine (engineForConversation, which can be 'codex') was only read later when calling window.cerebro.agent.run, so a missing Claude Code install blocked every send path including Codex-driven ones.

## Fix

- Destructure codexInfo from useProviders and mirror it into a codexInfoRef alongside the existing claudeCodeInfoRef in ChatProvider.
- Add an engineUnavailableError(conversationId) helper that resolves the conversation's engine via engineForConversationRef and checks the matching provider's status — Codex gets a 'Codex not detected' error, Claude Code keeps its existing message; returns null when the selected engine is available.
- Replace the hard-coded Claude Code guards at the top of sendMessage (resolving against activeConversationId) and regenerateFromUserMessage (resolving against activeConversationIdRef) with the new helper, and add engineUnavailableError to both callbacks' dependency arrays.

## Test plan

New `src/context/ChatContext.engine-gate.test.tsx` covers:
- `allows Codex chat when Claude Code is missing` — With Codex selected + available and Claude Code 'unavailable', no 'Claude Code not detected' error surfaces and agent.run is called with engine: 'codex'.
- `still blocks Claude Code chat when Claude Code is missing` — Control: with Claude Code selected but 'unavailable', the 'Claude Code not detected' error shows and agent.run is not called.
- `blocks Codex chat when Codex is missing` — With Codex selected but 'unavailable', a 'Codex not detected' error shows and agent.run is not called.

Manual verification: Ran the new test file and the full vitest suite (1115 passed, 17 skipped) plus tsc --noEmit (no new errors in the changed files). Verified the two engine-mismatch cases fail against the unfixed source (git-stashed the fix) and pass after restoring it.

## Notes

- The issue's suggested test used `status: 'missing'`, but the real EngineInfo type (src/engines/types.ts) has no such value — the tests use the actual 'unavailable' status instead.
- A full Playwright/Electron screenshot wasn't reachable here: reproducing the exact 'Codex installed + signed in, Claude Code missing' profile needs both CLIs and the Python backend, so the fix is proven via a component-level UI test that renders the real ChatProvider and asserts on the error-modal gating and agent.run engine argument.

## Evidence

### Tests
- `failing_test_diff` — 9296 bytes · sha256:33ad0020d668 · captured in the run audit log
- `patch` — 9296 bytes · sha256:33ad0020d668 · captured in the run audit log
- `test_output` — 33 bytes · sha256:94ba302f9610 · captured in the run audit log
- `test_output` — 121 bytes · sha256:6f0b0d8c81a1 · captured in the run audit log

### Screenshots
_Verified by an automated UI test — see the Test plan below._

### Logs
_(not applicable — no backend changes in this PR)_

### Reasoning
See the reasoning in this PR and the linked audit log.

---

_Co-authored by [Obelisk](https://github.com/HackerHouse-io/Obelisk)_ · _Reply `/obelisk explain` for the full reasoning trace._