### PR TITLE
fix: Saving replacement Slack tokens restarts the bridge instead of…

### DIFF
--- a/src/components/screens/integrations/SlackSection.tsx
+++ b/src/components/screens/integrations/SlackSection.tsx
@@ -35,6 +35,7 @@ export default function SlackSection({ showHeader = false }: SlackSectionProps =
   const [verify, setVerify] = useState<VerifyState>({ kind: 'idle' });
   const [status, setStatus] = useState<SlackStatusResponse | null>(null);
   const [savedFlash, setSavedFlash] = useState(false);
+  const [saveWarn, setSaveWarn] = useState<string | null>(null);
   const [enabling, setEnabling] = useState(false);
 
   useEffect(() => {
@@ -115,8 +116,15 @@ export default function SlackSection({ showHeader = false }: SlackSectionProps =
   const handleSave = useCallback(async () => {
     const channels = parseList(allowChans, ['C', 'G', 'D']);
     const users = parseList(allowUsers, ['U', 'W']);
+    setSaveWarn(null);
     const tokenRes = await persistTokensIfDraft();
-    if (!tokenRes.ok) return;
+    if (!tokenRes.ok) {
+      // Replacing tokens on a live bridge is persisted but not hot-applied;
+      // surface the re-enable warning instead of silently doing nothing.
+      setSaveWarn(tokenRes.error ?? 'Could not save tokens.');
+      await refreshStatus();
+      return;
+    }
     await Promise.all([
       saveSetting(SLACK_SETTING_KEYS.allowlistChannels, channels),
       saveSetting(SLACK_SETTING_KEYS.allowlistUsers, users),
@@ -372,6 +380,13 @@ export default function SlackSection({ showHeader = false }: SlackSectionProps =
       <UserExpertAccessEditor status={status} />
 
       {/* Save */}
+      {saveWarn && (
+        <div className="mt-4 flex items-start gap-2.5 px-3 py-2.5 rounded-md border border-warning/30 bg-warning/10 text-xs text-warning-text">
+          <ShieldAlert size={14} className="shrink-0 mt-px" />
+          <span>{saveWarn}</span>
+        </div>
+      )}
+
       <div className="mt-5 flex items-center justify-end gap-3">
         {savedFlash && (
           <span className="text-sm text-emerald-400 flex items-center gap-1.5">

--- a/src/components/screens/integrations/__tests__/SlackSection-token-replace.test.tsx
+++ b/src/components/screens/integrations/__tests__/SlackSection-token-replace.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Regression test for issue #31 — replacing Slack tokens while the bridge is
+ * running must NOT silently hot-restart it. The save handler surfaces the
+ * "disable and re-enable Slack" warning returned by setTokens and never calls
+ * reload (which would otherwise quietly bounce the live bridge).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import '../../../../i18n';
+import SlackSection from '../SlackSection';
+import type { SlackStatusResponse } from '../../../../types/ipc';
+
+// UserExpertAccessEditor pulls in ExpertContext, which is irrelevant to this
+// test and would otherwise require a provider wrapper.
+vi.mock('../UserExpertAccessEditor', () => ({ default: () => null }));
+
+const RUNNING_STATUS: SlackStatusResponse = {
+  running: true,
+  lastEventAt: null,
+  lastError: null,
+  teamName: 'Acme',
+  botUserId: 'U0BOT',
+  hasBotToken: true,
+  hasAppToken: true,
+  tokenBackend: 'os-keychain',
+  enabled: true,
+  allowlistChannels: [],
+  allowlistUsers: [],
+  operatorUserId: null,
+};
+
+function stubBridge() {
+  const setTokens = vi.fn().mockResolvedValue({
+    ok: false,
+    error: 'Tokens changed — disable and re-enable Slack to apply.',
+  });
+  const reload = vi.fn().mockResolvedValue({ ok: true });
+  (window as unknown as { cerebro: unknown }).cerebro = {
+    invoke: vi.fn().mockResolvedValue({ ok: false }),
+    slack: {
+      status: vi.fn().mockResolvedValue(RUNNING_STATUS),
+      verify: vi.fn(),
+      setTokens,
+      clearTokens: vi.fn().mockResolvedValue({ ok: true }),
+      setAllowlist: vi.fn().mockResolvedValue({ ok: true }),
+      setOperatorUserId: vi.fn().mockResolvedValue({ ok: true }),
+      reload,
+      enable: vi.fn().mockResolvedValue({ ok: true }),
+      disable: vi.fn().mockResolvedValue({ ok: true }),
+    },
+  };
+  return { setTokens, reload };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('SlackSection — token replacement while running (issue #31)', () => {
+  it('shows the re-enable warning and does not reload the live bridge', async () => {
+    const { setTokens, reload } = stubBridge();
+    render(<SlackSection />);
+
+    // Wait for the running status (with configured tokens) to load.
+    const replaceBtn = await screen.findByRole('button', { name: 'Replace' });
+    fireEvent.click(replaceBtn);
+
+    fireEvent.change(screen.getByPlaceholderText('xoxb-…'), {
+      target: { value: 'xoxb-new-bot-token' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('xapp-…'), {
+      target: { value: 'xapp-new-app-token' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    // The bridge-supplied warning must be surfaced to the operator.
+    await waitFor(() =>
+      expect(screen.getByText(/disable and re-enable Slack/i)).toBeInTheDocument(),
+    );
+
+    expect(setTokens).toHaveBeenCalledWith({
+      botToken: 'xoxb-new-bot-token',
+      appToken: 'xapp-new-app-token',
+    });
+    // reload() would bounce the live bridge — it must NOT be called.
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/src/slack/__tests__/bridge-set-tokens.test.ts
+++ b/src/slack/__tests__/bridge-set-tokens.test.ts
@@ -9,6 +9,22 @@
 import EventEmitter from 'node:events';
 import http from 'node:http';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// SlackBridge → secure-token.ts does `import { safeStorage } from 'electron'`, a
+// runtime value import. CI installs deps with `npm ci --ignore-scripts`, so the
+// electron binary is absent and a real require throws "Electron failed to
+// install correctly". Mock it (encryption-unavailable, the headless fallback
+// the code already handles) so the import resolves without the native binary.
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: (s: string) => Buffer.from(s),
+    decryptString: (b: Buffer) => b.toString(),
+  },
+  app: { getPath: () => '/tmp', getName: () => 'cerebro' },
+  ipcMain: { handle: () => undefined, on: () => undefined },
+}));
+
 import { SlackBridge } from '../bridge';
 
 // Absorb the backend /settings/{key} PUTs setTokens issues so the bridge can

--- a/src/slack/__tests__/bridge-set-tokens.test.ts
+++ b/src/slack/__tests__/bridge-set-tokens.test.ts
@@ -25,6 +25,13 @@ vi.mock('electron', () => ({
   ipcMain: { handle: () => undefined, on: () => undefined },
 }));
 
+// SlackBridge → claude-code/login-orchestrator does `import * as pty from
+// 'node-pty'`, a runtime value import that loads the native `pty.node` binary.
+// Under `npm ci --ignore-scripts` that binary is never built, so the real
+// require throws "Cannot find module .../pty.node". Mock it — this test never
+// spawns a pty — so the import chain resolves without the native module.
+vi.mock('node-pty', () => ({ spawn: () => undefined }));
+
 import { SlackBridge } from '../bridge';
 
 // Absorb the backend /settings/{key} PUTs setTokens issues so the bridge can

--- a/src/slack/__tests__/bridge-set-tokens.test.ts
+++ b/src/slack/__tests__/bridge-set-tokens.test.ts
@@ -1,0 +1,94 @@
+/**
+ * SlackBridge.setTokens — token replacement should NOT hot-restart a live
+ * bridge. Replacing bot/app tokens while Slack is running must persist the new
+ * tokens but leave the running bridge untouched, returning a warning that tells
+ * the operator to disable and re-enable Slack so the change applies cleanly.
+ *
+ * Regression test for #31.
+ */
+import EventEmitter from 'node:events';
+import http from 'node:http';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { SlackBridge } from '../bridge';
+
+// Absorb the backend /settings/{key} PUTs setTokens issues so the bridge can
+// "persist" tokens without a real backend running.
+let server: http.Server;
+let port = 0;
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    req.resume();
+    req.on('end', () => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address();
+  port = typeof addr === 'object' && addr ? addr.port : 0;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+function makeBridge() {
+  return new SlackBridge({
+    backendPort: port,
+    agentRuntime: {} as never,
+    dataDir: '/tmp',
+    engineEventBus: new EventEmitter(),
+  });
+}
+
+describe('SlackBridge.setTokens', () => {
+  it('does not hot-restart Slack when saving replacement tokens while running', async () => {
+    const bridge = makeBridge();
+    // Simulate a live bridge with the old token pair already loaded.
+    (bridge as unknown as { running: boolean }).running = true;
+    (bridge as unknown as { settings: Record<string, unknown> }).settings = {
+      botToken: 'old-bot',
+      appToken: 'old-app',
+      enabled: true,
+    };
+
+    const stopSpy = vi.spyOn(bridge, 'stop').mockResolvedValue();
+    const startSpy = vi.spyOn(bridge, 'start').mockResolvedValue();
+
+    const result = await bridge.setTokens({ botToken: 'new-bot', appToken: 'new-app' });
+
+    expect(result).toEqual({
+      ok: false,
+      error: expect.stringMatching(/disable and re-enable Slack/i),
+    });
+    expect(stopSpy).not.toHaveBeenCalled();
+    expect(startSpy).not.toHaveBeenCalled();
+    // The running bridge keeps its original live tokens until re-enable.
+    const settings = (bridge as unknown as { settings: { botToken: string; appToken: string } }).settings;
+    expect(settings.botToken).toBe('old-bot');
+    expect(settings.appToken).toBe('old-app');
+  });
+
+  it('persists tokens normally when the bridge is not running', async () => {
+    const bridge = makeBridge();
+    (bridge as unknown as { running: boolean }).running = false;
+    (bridge as unknown as { settings: Record<string, unknown> }).settings = {
+      botToken: null,
+      appToken: null,
+      enabled: false,
+    };
+
+    const stopSpy = vi.spyOn(bridge, 'stop').mockResolvedValue();
+    const startSpy = vi.spyOn(bridge, 'start').mockResolvedValue();
+
+    const result = await bridge.setTokens({ botToken: 'new-bot', appToken: 'new-app' });
+
+    expect(result).toEqual({ ok: true });
+    expect(stopSpy).not.toHaveBeenCalled();
+    expect(startSpy).not.toHaveBeenCalled();
+    const settings = (bridge as unknown as { settings: { botToken: string; appToken: string } }).settings;
+    expect(settings.botToken).toBe('new-bot');
+    expect(settings.appToken).toBe('new-app');
+  });
+});

--- a/src/slack/bridge.ts
+++ b/src/slack/bridge.ts
@@ -463,20 +463,34 @@ export class SlackBridge implements SlackChannel {
 
       const botVal = args.botToken ? encryptForStorage(args.botToken) : '';
       const appVal = args.appToken ? encryptForStorage(args.appToken) : '';
+
+      // Replacing tokens (both present) on a live bridge must NOT hot-restart.
+      // We persist the new pair so a later disable→enable picks it up, but we
+      // leave the running bridge — and its in-memory tokens — untouched and ask
+      // the operator to re-enable. Otherwise the bridge would silently bounce,
+      // dropping in-flight Socket Mode runs.
+      const isReplacement = Boolean(args.botToken && args.appToken);
+      if (wasRunning && isReplacement) {
+        const changed = args.botToken !== this.settings.botToken
+          || args.appToken !== this.settings.appToken;
+        if (changed) {
+          await backendPutSetting(port, SLACK_SETTING_KEYS.botToken, botVal);
+          await backendPutSetting(port, SLACK_SETTING_KEYS.appToken, appVal);
+          return { ok: false, error: 'Tokens changed — disable and re-enable Slack to apply.' };
+        }
+        return { ok: true };
+      }
+
       await backendPutSetting(port, SLACK_SETTING_KEYS.botToken, botVal);
       await backendPutSetting(port, SLACK_SETTING_KEYS.appToken, appVal);
 
       this.settings.botToken = args.botToken;
       this.settings.appToken = args.appToken;
 
+      // Remaining live cases (clearing tokens, or a partial pair) stop the
+      // bridge and stay off — the bridge can't run without a full token pair.
       if (wasRunning) {
         await this.stop();
-        if (args.botToken && args.appToken) {
-          await this.start();
-          if (!this.running) {
-            return { ok: false, error: this.lastError ?? 'Failed to restart with new tokens' };
-          }
-        }
       }
       return { ok: true };
     } catch (err) {


### PR DESCRIPTION
Fixes #31.

## Summary

When Slack was running and an operator replaced the bot/app tokens via Settings → Slack and clicked Save, the bridge silently stopped and hot-restarted with the new tokens — dropping any in-flight Socket Mode runs. The expected behavior, matching the existing reload-warning path, is for the save to persist the new tokens and ask the operator to disable and re-enable Slack so the swap is intentional and clean.

## Root cause

`SlackBridge.setTokens()` in `src/slack/bridge.ts` immediately updated its in-memory tokens and, when `wasRunning` was true, called `stop()` then `start()`. Because the UI save path (`handleSave` in `src/components/screens/integrations/SlackSection.tsx`) calls `setTokens()` before `reload()`, the tokens were already applied by the time `reloadSettings()` ran, so its `this.settings.botToken !== prevBot` guard never detected a change and the re-enable warning was bypassed.

## Fix

- Rework `SlackBridge.setTokens()` so that replacing both tokens while the bridge is running persists the new pair to the backend but leaves the live bridge (and its in-memory tokens) untouched, returning `{ ok: false, error: 'Tokens changed — disable and re-enable Slack to apply.' }`. Clearing/partial-token paths still stop the bridge as before.
- Update `handleSave` in `SlackSection.tsx` to surface the warning returned by `setTokens()` via a new `saveWarn` state instead of returning silently, and refresh status.
- Render the warning in a warning banner above the Save button so the operator sees the re-enable instruction.

## Test plan

New `src/slack/__tests__/bridge-set-tokens.test.ts` covers:
- `does not hot-restart Slack when saving replacement tokens while running` — setTokens returns the disable/re-enable warning, never calls stop()/start(), and keeps the running bridge's original in-memory tokens
- `persists tokens normally when the bridge is not running` — setTokens returns ok and updates in-memory tokens without stop/start when the bridge is off
- `shows the re-enable warning and does not reload the live bridge` — (UI, SlackSection-token-replace.test.tsx) saving replacement tokens while running renders the warning and never calls slack.reload()

Manual verification: Ran the full vitest suite (1115 passed, 17 skipped) and the targeted Slack bridge + SlackSection UI tests; confirmed the previously-failing bridge test now passes and no existing tests regressed.

## Notes

- Playwright screenshot was not feasible: the Slack bridge runs in the Electron main process and requires a real Slack workspace + live Socket Mode connection, so the fix is proven with an automated DOM UI test (rung 2) plus the bridge unit test.

## Evidence

### Tests
- `patch` — 11663 bytes · sha256:9db289e03364 · captured in the run audit log
- `failing_test_diff` — 11663 bytes · sha256:9db289e03364 · captured in the run audit log
- `test_output` — 158 bytes · sha256:c73e03f1a091 · captured in the run audit log
- `test_output` — 33 bytes · sha256:94ba302f9610 · captured in the run audit log

### Screenshots
_Verified by an automated UI test — see the Test plan below._

### Logs
_(not applicable — no backend changes in this PR)_

### Reasoning
See the reasoning in this PR and the linked audit log.

---

_Co-authored by [Obelisk](https://github.com/HackerHouse-io/Obelisk)_ · _Reply `/obelisk explain` for the full reasoning trace._