### PR TITLE
fix: Claude unavailable modal is hardcoded in English

### DIFF
--- a/src/context/ChatContext.engine-gate.test.tsx
+++ b/src/context/ChatContext.engine-gate.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, act } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ReactNode } from 'react';
 import { ChatProvider, useChat } from './ChatContext';
+import i18n from '../i18n';
 import type { ClaudeCodeInfo } from '../types/providers';
 import type { EngineId } from '../engines/types';
 
@@ -68,11 +69,13 @@ function installCerebroMock() {
 // Test harness: renders the provider and exposes sendMessage + chatError.
 let sendRef: (content: string) => void;
 let errorTitle: string | null;
+let errorMessage: string | null;
 
 function Harness() {
   const { sendMessage, chatError } = useChat();
   sendRef = sendMessage;
   errorTitle = chatError?.title ?? null;
+  errorMessage = chatError?.message ?? null;
   return <div data-testid="error">{chatError?.title ?? 'no-error'}</div>;
 }
 
@@ -97,6 +100,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
+  i18n.changeLanguage('en');
 });
 
 describe('ChatContext engine availability gate', () => {
@@ -146,6 +150,43 @@ describe('ChatContext engine availability gate', () => {
     });
 
     expect(errorTitle).toBe('Codex not detected');
+    expect(agentRun).not.toHaveBeenCalled();
+  });
+
+  it('localizes the Claude-Code-unavailable modal to Spanish', async () => {
+    i18n.changeLanguage('es');
+    mockClaudeCodeInfo = { status: 'unavailable' };
+    mockCodexInfo = { status: 'available' };
+    mockDefaultEngine = 'claude-code';
+
+    renderChat();
+
+    await act(async () => {
+      sendRef('hola');
+    });
+
+    // Bug: the modal title/message were hardcoded English regardless of locale.
+    expect(errorTitle).toBe('Claude Code no detectado');
+    expect(errorTitle).not.toBe('Claude Code not detected');
+    expect(errorMessage).toContain('Integraciones');
+    expect(agentRun).not.toHaveBeenCalled();
+  });
+
+  it('localizes the Codex-unavailable modal to Spanish', async () => {
+    i18n.changeLanguage('es');
+    mockClaudeCodeInfo = { status: 'available' };
+    mockCodexInfo = { status: 'unavailable' };
+    mockDefaultEngine = 'codex';
+
+    renderChat();
+
+    await act(async () => {
+      sendRef('hola');
+    });
+
+    expect(errorTitle).toBe('Codex no detectado');
+    expect(errorTitle).not.toBe('Codex not detected');
+    expect(errorMessage).toContain('Integraciones');
     expect(agentRun).not.toHaveBeenCalled();
   });
 });

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -209,9 +209,8 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       if (engine === 'codex') {
         if (codexInfoRef.current.status !== 'available') {
           return {
-            title: 'Codex not detected',
-            message:
-              'Cerebro is set to use the Codex CLI as its engine. Install it and re-detect from Integrations.',
+            title: i18n.t('chat.codexNotDetectedTitle'),
+            message: i18n.t('chat.codexNotDetectedMessage'),
             navigateTo: 'integrations',
           };
         }
@@ -219,9 +218,8 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       }
       if (claudeCodeInfoRef.current.status !== 'available') {
         return {
-          title: 'Claude Code not detected',
-          message:
-            'Cerebro uses the Claude Code CLI as its engine. Install it and re-detect from Integrations.',
+          title: i18n.t('chat.claudeNotDetectedTitle'),
+          message: i18n.t('chat.claudeNotDetectedMessage'),
           navigateTo: 'integrations',
         };
       }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -77,6 +77,12 @@ const en = {
     stoppedMarker: '_(stopped)_',
     busyRetry: 'I’m still finishing your previous message — give it a moment and try again.',
     startFailed: 'Something went wrong on my end. Please try again in a moment.',
+    claudeNotDetectedTitle: 'Claude Code not detected',
+    claudeNotDetectedMessage:
+      'Cerebro uses the Claude Code CLI as its engine. Install it and re-detect from Integrations.',
+    codexNotDetectedTitle: 'Codex not detected',
+    codexNotDetectedMessage:
+      'Cerebro is set to use the Codex CLI as its engine. Install it and re-detect from Integrations.',
     edit: 'Edit message',
     save: 'Save',
     cancel: 'Cancel',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -78,6 +78,12 @@ const es: TranslationKeys = {
     stoppedMarker: '_(detenido)_',
     busyRetry: 'Todavía estoy terminando tu mensaje anterior. Dale un momento e inténtalo de nuevo.',
     startFailed: 'Algo salió mal de mi lado. Por favor, inténtalo de nuevo en un momento.',
+    claudeNotDetectedTitle: 'Claude Code no detectado',
+    claudeNotDetectedMessage:
+      'Cerebro usa la CLI de Claude Code como su motor. Instálala y vuelve a detectarla desde Integraciones.',
+    codexNotDetectedTitle: 'Codex no detectado',
+    codexNotDetectedMessage:
+      'Cerebro está configurado para usar la CLI de Codex como su motor. Instálala y vuelve a detectarla desde Integraciones.',
     edit: 'Editar mensaje',
     save: 'Guardar',
     cancel: 'Cancelar',


### PR DESCRIPTION
Fixes #15.

## Summary

When Cerebro's language was set to Spanish, the modal that appears when the selected engine (Claude Code or Codex) isn't installed still rendered its title and body in English (e.g. "Claude Code not detected"). Every other user-facing string in the app is bilingual, so this modal was an inconsistency that broke the Spanish experience at exactly the moment a user needs clear guidance.

## Root cause

In src/context/ChatContext.tsx, engineUnavailableError() returned ChatError objects with hardcoded English string literals for both title and message in the Codex branch and the Claude Code branch, instead of resolving them through i18n. The AppLayout AlertModal renders chatError.title/message verbatim, so the hardcoded English text reached the UI regardless of i18n.language.

## Fix

- Replace the hardcoded English title/message literals in engineUnavailableError() (src/context/ChatContext.tsx) with i18n.t('chat.claudeNotDetectedTitle'/'...Message') and the codex equivalents.
- Add chat.claudeNotDetectedTitle, chat.claudeNotDetectedMessage, chat.codexNotDetectedTitle, and chat.codexNotDetectedMessage to src/i18n/locales/en.ts (preserving the original wording).
- Add the Spanish translations of the same four keys to src/i18n/locales/es.ts.

## Test plan

New `src/context/ChatContext.engine-gate.test.tsx` covers:
- `localizes the Claude-Code-unavailable modal to Spanish` — With i18n set to 'es' and Claude Code unavailable, chatError.title is 'Claude Code no detectado' and the message references 'Integraciones'
- `localizes the Codex-unavailable modal to Spanish` — With i18n set to 'es' and Codex unavailable, chatError.title is 'Codex no detectado' and the message references 'Integraciones'

Manual verification: Ran the full vitest suite (1118 passing, 17 skipped); the two new Spanish-locale cases fail before the fix and pass after, while the three pre-existing English engine-gate assertions remain green.

## Notes

- i18n key typing is derived from en.ts via src/i18n/types.ts, so the four new keys are automatically type-checked across both locales — no separate type registration needed.

## Evidence

### Tests
- `patch` — 5714 bytes · sha256:f3f5fdfbcca7 · captured in the run audit log
- `failing_test_diff` — 5714 bytes · sha256:f3f5fdfbcca7 · captured in the run audit log
- `test_output` — 118 bytes · sha256:a925dc6a342b · captured in the run audit log
- `test_output` — 33 bytes · sha256:94ba302f9610 · captured in the run audit log

### Screenshots
_Verified by an automated UI test — see the Test plan below._

### Logs
_(not applicable — no backend changes in this PR)_

### Reasoning
See the reasoning in this PR and the linked audit log.

---

_Co-authored by [Obelisk](https://github.com/HackerHouse-io/Obelisk)_ · _Reply `/obelisk explain` for the full reasoning trace._