### PR TITLE
fix: Missing Slack file path throws before structured action failure

### DIFF
--- a/src/engine/__tests__/send-slack-file.test.ts
+++ b/src/engine/__tests__/send-slack-file.test.ts
@@ -133,6 +133,18 @@ describe('createSendSlackFileAction', () => {
     })).rejects.toThrow(/Send Slack File: must provide either file_item_id or file_path/);
   });
 
+  it('returns sent:false for a missing local file path without uploading', async () => {
+    resolveMediaInputMock.mockRejectedValue(new Error('file_path not found on disk: /tmp/missing.pdf'));
+    const result = await action.execute({
+      params: { channel: 'C01ABCDE', file_path: '/tmp/missing.pdf' },
+      wiredInputs: {},
+      scratchpad: new RunScratchpad(),
+      context: makeContext(),
+    });
+    expect(result.data).toEqual({ sent: false, file_id: null, channel: 'C01ABCDE', error: 'file not found: /tmp/missing.pdf' });
+    expect(channel.calls).toHaveLength(0);
+  });
+
   it('returns sent:false when upload fails', async () => {
     channel.reply = { fileId: null, error: 'file_too_large' };
     const ctx = makeContext();

--- a/src/engine/actions/send-slack-file.ts
+++ b/src/engine/actions/send-slack-file.ts
@@ -102,6 +102,21 @@ export function createSendSlackFileAction(deps: { getChannel: () => SlackChannel
         resolved = await resolveMediaInput(input.context.backendPort, fileItemId, filePath);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
+        // A missing local file is an expected failed send, not an action exception.
+        // The Slack bridge already returns {fileId:null, error:'file not found: …'}
+        // for this case (see SlackBridge.sendFileActionMessage); the resolver's
+        // existence check just fires first. Translate it back into that structured
+        // result so routines/chat actions see sent:false instead of an uncaught
+        // throw. Other resolver errors (bad/absent input) still surface as throws.
+        if (filePath && /not found on disk/.test(msg)) {
+          const missingPath = filePath.startsWith('@/') ? filePath.slice(1) : filePath;
+          const error = `file not found: ${missingPath}`;
+          input.context.log(`Slack file upload failed for ${channelId}: ${error}`);
+          return {
+            data: { sent: false, file_id: null, channel: channelId, error },
+            summary: `Slack file upload failed: ${error}`,
+          };
+        }
         throw new Error(`Send Slack File: ${msg}`);
       }
 


### PR DESCRIPTION
Fixes #54.

## Summary

Running send_slack_file with a nonexistent local file_path raised an uncaught exception (`Send Slack File: file_path not found on disk: …`) instead of returning a structured failed send. Every other failure mode of this action — bad channel, rate limit, oversized file — returns `{sent:false, error:…}` so routines and chat actions can handle it gracefully; a missing file was the one case that threw. It now returns the same structured `file not found: …` result the Slack bridge itself produces, without ever calling Slack upload.

## Root cause

`resolveMediaInput` in src/engine/actions/utils/media-resolver.ts:57-59 throws `file_path not found on disk: …` when `fs.existsSync` is false. In createSendSlackFileAction (src/engine/actions/send-slack-file.ts), the catch block around the resolver rethrew every resolver error wrapped in a `Send Slack File:` prefix, so the missing-file case surfaced as an exception. The Slack bridge already handles this exact case structurally (SlackBridge.sendFileActionMessage at src/slack/bridge.ts:786-788 returns `{fileId:null, error:'file not found: …'}`), but the resolver's existence check fired first and short-circuited it.

## Fix

- In createSendSlackFileAction's resolver catch block (src/engine/actions/send-slack-file.ts), detect a missing-file resolver error (`file_path` present and message matches `not found on disk`) and return `{sent:false, file_id:null, channel, error:'file not found: <path>'}` — mirroring the bridge's own contract — instead of rethrowing.
- Strip the leading `@/` chat-attachment sentinel from the path when building the error message so it matches the normalized path the resolver/bridge would report.
- Leave all other resolver errors (missing input, non-absolute path, file_item bytes missing) rethrowing with the `Send Slack File:` prefix, preserving existing behavior.

## Test plan

New `src/engine/__tests__/send-slack-file.test.ts` covers:
- `returns sent:false for a missing local file path without uploading` — Action returns {sent:false, file_id:null, channel:'C01ABCDE', error:'file not found: /tmp/missing.pdf'} and channel.sendFileActionMessage is never called (channel.calls is empty).

Manual verification: Ran `npx vitest run src/engine` — all 43 files / 458 tests pass, including the existing 'rethrows resolver failures with a Send Slack File prefix' test that confirms non-missing-file resolver errors still throw.

## Evidence

### Tests
- `patch` — 2703 bytes · sha256:c677f734a175 · captured in the run audit log
- `failing_test_diff` — 2703 bytes · sha256:c677f734a175 · captured in the run audit log
- `test_output` — 33 bytes · sha256:94ba302f9610 · captured in the run audit log

### Screenshots
_Verified manually by the author — see the note above._

### Logs
_(not applicable — no backend changes in this PR)_

### Reasoning
See the reasoning in this PR and the linked audit log.

---

_Co-authored by [Obelisk](https://github.com/HackerHouse-io/Obelisk)_ · _Reply `/obelisk explain` for the full reasoning trace._