### PR TITLE
fix: Top-level Slack mentions post bot replies outside the message thread

### DIFF
--- a/src/slack/__tests__/bridge-mention-threading.test.ts
+++ b/src/slack/__tests__/bridge-mention-threading.test.ts
@@ -1,0 +1,137 @@
+/**
+ * SlackBridge app_mention threading — a top-level channel @mention must reply
+ * INSIDE the triggering message's thread, not as separate top-level channel
+ * messages.
+ *
+ * Regression test for #52. Slack only delivers `thread_ts` when the mention was
+ * already inside a thread, so a fresh top-level mention arrives with
+ * `threadTs: undefined`. handleInbound must fall back to the mention's own `ts`
+ * as the thread root for channel mentions, so the "thinking…" placeholder and
+ * the final answer land under the original message instead of cluttering the
+ * channel.
+ */
+import EventEmitter from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+
+// SlackBridge → secure-token.ts does `import { safeStorage } from 'electron'`, a
+// runtime value import. CI installs deps with `npm ci --ignore-scripts`, so the
+// electron binary is absent and a real require throws. Mock it
+// (encryption-unavailable, the headless fallback the code already handles).
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: (s: string) => Buffer.from(s),
+    decryptString: (b: Buffer) => b.toString(),
+  },
+  app: { getPath: () => '/tmp', getName: () => 'cerebro' },
+  ipcMain: { handle: () => undefined, on: () => undefined },
+}));
+
+// SlackBridge → claude-code/login-orchestrator does `import * as pty from
+// 'node-pty'`, a runtime value import that loads a native binary absent under
+// `npm ci --ignore-scripts`. Mock it — this test never spawns a pty.
+vi.mock('node-pty', () => ({ spawn: () => undefined }));
+
+import { SlackBridge } from '../bridge';
+
+function makeBridge(api: { chatPostMessage: ReturnType<typeof vi.fn> }) {
+  const runtime = {
+    startRun: vi.fn(async () => 'run-1'),
+    cancelRun: vi.fn(),
+  };
+  const bridge = new SlackBridge({
+    backendPort: 9,
+    agentRuntime: runtime as never,
+    dataDir: '/tmp',
+    engineEventBus: new EventEmitter(),
+  });
+
+  // Wire up a live-but-stubbed bridge: real api handle, running, and an
+  // allowlist that admits the test channel + user.
+  Object.assign(bridge as unknown as Record<string, unknown>, {
+    api,
+    running: true,
+    settings: {
+      allowlistChannels: ['C1'],
+      allowlistUsers: ['U1'],
+      threadConversationMap: {},
+      threadExpertMap: {},
+      userDisplayNames: {},
+      defaultExpertAccess: null,
+      userExpertAccess: {},
+      botToken: 'x',
+      appToken: 'y',
+      enabled: true,
+      teamName: null,
+      botUserId: 'UBOT',
+      operatorUserId: null,
+    },
+  });
+
+  // Short-circuit the persistence / routing collaborators that need a backend.
+  vi.spyOn(bridge as never, 'buildPromptFromContext').mockResolvedValue(undefined as never);
+  vi.spyOn(bridge as never, 'resolveConversation').mockResolvedValue({
+    conversationId: 'conv1',
+    reused: false,
+  } as never);
+  vi.spyOn(bridge as never, 'postUserMessageWithRecovery').mockResolvedValue('conv1' as never);
+  vi.spyOn(bridge as never, 'emitConversationUpdated').mockImplementation(() => undefined);
+  vi.spyOn(bridge as never, 'matchSlackTriggers').mockResolvedValue([] as never);
+  vi.spyOn(bridge as never, 'getAccessibleExpertIds').mockReturnValue(null as never);
+
+  return bridge;
+}
+
+describe('SlackBridge app_mention threading', () => {
+  it('replies to a top-level mention inside the mention thread', async () => {
+    const api = {
+      chatPostMessage: vi.fn(async (args: { channel: string }) => ({ ts: '2.000', channel: args.channel })),
+    };
+    const bridge = makeBridge(api);
+
+    await (bridge as unknown as { handleInbound: (ctx: unknown) => Promise<void> }).handleInbound({
+      eventId: 'Ev1',
+      teamId: 'T1',
+      channel: 'C1',
+      channelType: 'channel',
+      userId: 'U1',
+      ts: '123.456',
+      threadTs: undefined,
+      text: 'hi',
+      surface: 'app_mention',
+    });
+    // Let the sink's placeholder postMessage (fired from the constructor) settle.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The "thinking…" placeholder must be posted in-thread under the mention.
+    expect(api.chatPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ thread_ts: '123.456', text: '_Cerebro is thinking…_' }),
+    );
+  });
+
+  it('keeps an in-thread mention threaded under the original root', async () => {
+    const api = {
+      chatPostMessage: vi.fn(async (args: { channel: string }) => ({ ts: '2.000', channel: args.channel })),
+    };
+    const bridge = makeBridge(api);
+
+    await (bridge as unknown as { handleInbound: (ctx: unknown) => Promise<void> }).handleInbound({
+      eventId: 'Ev2',
+      teamId: 'T1',
+      channel: 'C1',
+      channelType: 'channel',
+      userId: 'U1',
+      ts: '200.000',
+      threadTs: '100.000',
+      text: 'hi again',
+      surface: 'app_mention',
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(api.chatPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ thread_ts: '100.000', text: '_Cerebro is thinking…_' }),
+    );
+  });
+});

--- a/src/slack/bridge.ts
+++ b/src/slack/bridge.ts
@@ -844,9 +844,10 @@ export class SlackBridge implements SlackChannel {
           channelType: 'channel',
           userId: event.user ?? '',
           ts: event.ts,
-          // Only set when Slack actually delivered a thread_ts (i.e. the
-          // mention was inside an existing thread). Leaving it undefined
-          // makes our reply land at the channel top level.
+          // Carries Slack's literal thread_ts — only present when the mention
+          // was already inside a thread. handleInbound falls back to `ts` as
+          // the thread root for top-level mentions so the reply still lands in
+          // the mention's thread rather than at the channel top level.
           threadTs: event.thread_ts,
           text: stripped,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1116,11 +1117,16 @@ export class SlackBridge implements SlackChannel {
       return;
     }
 
-    // 9. Start the agent run. Reply lands at the channel/DM top level unless
-    //    the inbound message was already inside an existing thread — keeps
-    //    Cerebro from forcing users to open a thread side panel for every
-    //    DM or top-level @mention.
-    const threadTsForReply = ctx.threadTs;
+    // 9. Start the agent run. Channel @mentions always reply inside the
+    //    triggering message's thread — Slack only delivers `thread_ts` when the
+    //    mention was already in a thread, so for a top-level mention we fall
+    //    back to the mention's own `ts` as the thread root. That keeps the
+    //    "thinking…" placeholder and the answer under the original message
+    //    instead of cluttering the channel with separate top-level posts.
+    //    DMs stay at the channel top level (no thread side panel).
+    const threadTsForReply = ctx.surface === 'app_mention'
+      ? (ctx.threadTs ?? ctx.ts)
+      : ctx.threadTs;
     const bumpActivity = () => {
       const r = this.activeRuns.get(key);
       if (r) r.lastActivityAt = Date.now();


### PR DESCRIPTION
Fixes #52.

## Summary

When a user @mentioned Cerebro with a fresh top-level message in a channel (not inside an existing thread), the bot's '_Cerebro is thinking…_' placeholder and its final answer were posted as new top-level channel messages instead of as replies under the triggering mention. This cluttered shared channels and broke the intended in-thread workflow. In-thread mentions already behaved correctly; this fix makes top-level mentions consistent with them.

## Root cause

In src/slack/bridge.ts, the app_mention handler set ctx.threadTs to Slack's literal event.thread_ts, which Slack only populates when the mention was already inside a thread — so a top-level mention arrives with threadTs undefined. handleInbound then computed threadTsForReply = ctx.threadTs (undefined) and passed it straight into SlackStreamSink and every chat.postMessage call, so Slack posted at the channel top level. The sink posts its placeholder from its constructor using deps.threadTs, which is why the undefined value surfaced immediately.

## Fix

- In handleInbound (src/slack/bridge.ts), compute threadTsForReply as `ctx.surface === 'app_mention' ? (ctx.threadTs ?? ctx.ts) : ctx.threadTs` so channel mentions fall back to the mention's own ts as the thread root while DMs stay at the top level.
- Update the now-stale comment on the app_mention handler's `threadTs: event.thread_ts` to explain that handleInbound supplies the ts fallback, avoiding future confusion.

## Test plan

New `src/slack/__tests__/bridge-mention-threading.test.ts` covers:
- `replies to a top-level mention inside the mention thread` — handleInbound with surface 'app_mention', threadTs undefined, ts '123.456' posts the placeholder with thread_ts '123.456' (was undefined before the fix)
- `keeps an in-thread mention threaded under the original root` — handleInbound with an existing threadTs '100.000' still posts the placeholder under thread_ts '100.000' (no regression for already-threaded mentions)

Manual verification: Ran `npx vitest run src/slack` — all 91 Slack tests pass; the new top-level-mention case fails on the pre-fix code and passes after. `npx tsc --noEmit` reports no errors in the changed files.

## Notes

- Fix lives in handleInbound rather than the app_mention handler on purpose: ctx.threadTs is also consumed by conversationKey to distinguish 'thread' vs 'mention' conversation surfaces, so overwriting it at intake would change conversation keying and thread-backfill behavior. Deriving the reply target locally keeps the change to the smallest correct slice.

## Evidence

### Tests
- `patch` — 7587 bytes · sha256:d6c1944ea3e3 · captured in the run audit log
- `failing_test_diff` — 7587 bytes · sha256:d6c1944ea3e3 · captured in the run audit log
- `test_output` — 33 bytes · sha256:94ba302f9610 · captured in the run audit log

### Screenshots
_Verified manually by the author — see the note above._

### Logs
_(not applicable — no backend changes in this PR)_

### Reasoning
See the reasoning in this PR and the linked audit log.

---

_Co-authored by [Obelisk](https://github.com/HackerHouse-io/Obelisk)_ · _Reply `/obelisk explain` for the full reasoning trace._