### PR TITLE
fix: Routines list flashes empty state before the loading spinner on first…

### DIFF
--- a/src/components/screens/routines/__tests__/RoutineList.loading-flash.test.tsx
+++ b/src/components/screens/routines/__tests__/RoutineList.loading-flash.test.tsx
@@ -20,6 +20,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
+import { flushSync } from 'react-dom';
 import { render, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import '../../../../i18n';
@@ -79,17 +80,21 @@ describe('RoutineList loading flash (issue #55)', () => {
     document.body.appendChild(container);
     const root = createRoot(container);
 
-    // Render OUTSIDE act() so passive effects (RoutineList's mount-time
-    // loadRoutines) do NOT flush. Reading innerHTML now captures exactly the
-    // first frame the user sees on open — before any load has been kicked off.
+    // flushSync forces the initial commit synchronously while leaving passive
+    // effects (RoutineList's mount-time loadRoutines) deferred. Inspecting the
+    // DOM now captures exactly the first frame the user sees on open — before
+    // any load has been kicked off. IS_REACT_ACT_ENVIRONMENT=false keeps React
+    // from auto-flushing those effects.
     const prevActEnv = (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT;
     (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = false;
     try {
-      root.render(
-        <RoutineProvider>
-          <RoutineList />
-        </RoutineProvider>,
-      );
+      flushSync(() => {
+        root.render(
+          <RoutineProvider>
+            <RoutineList />
+          </RoutineProvider>,
+        );
+      });
 
       const html = container.innerHTML;
       expect(html).not.toContain('No routines yet');

--- a/src/components/screens/routines/__tests__/RoutineList.loading-flash.test.tsx
+++ b/src/components/screens/routines/__tests__/RoutineList.loading-flash.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Regression test for issue #55 — the Routines list flashes the empty state
+ * ("No routines yet") for one frame before the loading spinner on first open.
+ *
+ * Root cause: RoutineProvider initialised `isLoading` to `false`. On the very
+ * first synchronous paint — before RoutineList's mount effect calls
+ * loadRoutines() — the spinner gate (`isLoading && routines.length === 0`) was
+ * false, so the component fell through to the empty placeholder. The fix makes
+ * `isLoading` start `true`, because a load is always kicked off on mount, so
+ * the first frame shows the spinner instead.
+ *
+ * Two layers of coverage:
+ *   1. Provider unit test — the initial context value must report isLoading
+ *      before any consumer has triggered a load (the root cause, deterministic).
+ *   2. Component test — the first synchronous render of RoutineList must show
+ *      the spinner, never the empty placeholder, by inspecting the DOM before
+ *      passive effects flush (reproduces the user-visible flash).
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import '../../../../i18n';
+
+// RoutineProvider only consumes useToast/useExperts in callbacks; stub them so
+// the provider can mount without the full context tree or the IPC bridge.
+vi.mock('../../../../context/ToastContext', () => ({
+  useToast: () => ({ addToast: vi.fn(), toasts: [], dismissToast: vi.fn() }),
+}));
+vi.mock('../../../../context/ExpertContext', () => ({
+  useExperts: () => ({ experts: [] }),
+}));
+
+import { RoutineProvider, useRoutines } from '../../../../context/RoutineContext';
+import RoutineList from '../RoutineList';
+
+function stubBridge() {
+  // Keep the /routines load pending forever so isLoading stays in its
+  // mount-time value for the duration of the assertions.
+  (window as unknown as { cerebro: unknown }).cerebro = {
+    invoke: vi.fn(() => new Promise(() => {})),
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('RoutineList loading flash (issue #55)', () => {
+  it('provider starts in the loading state before any consumer triggers a load', () => {
+    stubBridge();
+
+    let captured: ReturnType<typeof useRoutines> | null = null;
+    function Probe() {
+      captured = useRoutines();
+      return null;
+    }
+
+    render(
+      <RoutineProvider>
+        <Probe />
+      </RoutineProvider>,
+    );
+
+    expect(captured).not.toBeNull();
+    // A load always fires on mount, so the very first state the UI sees must be
+    // "loading" — otherwise the empty placeholder flashes first.
+    expect(captured!.isLoading).toBe(true);
+    expect(captured!.routines).toHaveLength(0);
+  });
+
+  it('shows the spinner on the first paint, never the empty placeholder', () => {
+    stubBridge();
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    // Render OUTSIDE act() so passive effects (RoutineList's mount-time
+    // loadRoutines) do NOT flush. Reading innerHTML now captures exactly the
+    // first frame the user sees on open — before any load has been kicked off.
+    const prevActEnv = (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT;
+    (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = false;
+    try {
+      root.render(
+        <RoutineProvider>
+          <RoutineList />
+        </RoutineProvider>,
+      );
+
+      const html = container.innerHTML;
+      expect(html).not.toContain('No routines yet');
+      expect(container.querySelector('.animate-spin')).not.toBeNull();
+    } finally {
+      act(() => {
+        root.unmount();
+      });
+      (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = prevActEnv;
+      container.remove();
+    }
+  });
+});

--- a/src/context/RoutineContext.tsx
+++ b/src/context/RoutineContext.tsx
@@ -48,7 +48,10 @@ const SCHEDULE_FIELDS = new Set(['trigger_type', 'cron_expression', 'is_enabled'
 export function RoutineProvider({ children }: { children: ReactNode }) {
   const [routines, setRoutines] = useState<Routine[]>([]);
   const [total, setTotal] = useState(0);
-  const [isLoading, setIsLoading] = useState(false);
+  // Start in the loading state: RoutineList always kicks off a load on mount,
+  // so the first frame must show the spinner rather than briefly flashing the
+  // "No routines yet" empty placeholder before the load begins (issue #55).
+  const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [editingRoutineId, setEditingRoutineId] = useState<string | null>(null);
   const runCallbackRef = useRef<RunRoutineCallback | null>(null);


### PR DESCRIPTION
Fixes #55.

## Summary

On first open of the Routines screen, the 'No routines yet' empty placeholder flashed for one frame before the loading spinner appeared, even when the user actually had routines that were about to load in. The list now shows the spinner immediately on first paint and only renders the empty state once a load has genuinely completed with no results.

## Root cause

RoutineProvider in src/context/RoutineContext.tsx initialised `isLoading` with `useState(false)`. RoutineList's spinner gate is `isLoading && routines.length === 0`, but the load is only kicked off by RoutineList's mount `useEffect` (which runs after the first commit). So on the very first synchronous render the gate was false, the error branch was skipped, and the component fell through to the empty-state branch (`routines.length === 0`), flashing 'No routines yet' until the effect set `isLoading` true on the next render.

## Fix

- Initialise `isLoading` to `true` in RoutineProvider (src/context/RoutineContext.tsx) since a load always fires on mount, so the first frame shows the spinner instead of the empty placeholder.

## Test plan

New `src/components/screens/routines/__tests__/RoutineList.loading-flash.test.tsx` covers:
- `provider starts in the loading state before any consumer triggers a load` — RoutineProvider's initial context value reports isLoading === true with zero routines (root-cause guard)
- `shows the spinner on the first paint, never the empty placeholder` — RoutineList's first synchronous commit (via flushSync, passive effects deferred) renders a spinner and does not contain 'No routines yet' (reproduces the user-visible flash)

Manual verification: Ran the new test against the unpatched provider — both cases fail (isLoading false → empty state on first paint); with the fix both pass. Full vitest suite: 1248 passed, 0 regressions.

## Notes

- Playwright/Electron screenshot was not used — the flash is a sub-frame timing artifact that a live screenshot can't reliably capture; an automated test that inspects the first synchronous commit (before passive effects flush) proves it deterministically instead.

## Evidence

### Tests
- `patch` — 5601 bytes · sha256:3e9e2aa28798 · captured in the run audit log
- `failing_test_diff` — 5601 bytes · sha256:3e9e2aa28798 · captured in the run audit log
- `test_output` — 33 bytes · sha256:94ba302f9610 · captured in the run audit log
- `test_output` — 153 bytes · sha256:8a287e0fe93f · captured in the run audit log

### Screenshots
_Verified by an automated UI test — see the Test plan below._

### Logs
_(not applicable — no backend changes in this PR)_

### Reasoning
See the reasoning in this PR and the linked audit log.

---

_Co-authored by [Obelisk](https://github.com/HackerHouse-io/Obelisk)_ · _Reply `/obelisk explain` for the full reasoning trace._