### PR TITLE
fix: Experts > Hierarchy: Team cards nest the expand button inside the card…

### DIFF
--- a/src/components/screens/experts/DepartmentCard.tsx
+++ b/src/components/screens/experts/DepartmentCard.tsx
@@ -83,94 +83,100 @@ export default function DepartmentCard({
     >
       <div className="absolute left-0 top-0 bottom-0 w-[3px]" style={{ backgroundColor: accent }} />
 
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onSelectTeam();
-        }}
-        onContextMenu={(e) => onTeamContextMenu(team, e)}
-        className="expert-node w-full flex items-center gap-3 px-3.5 py-3 text-left hover:bg-bg-hover/50 transition-colors"
-      >
-        <div
-          className="relative w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0 overflow-hidden"
-          style={{
-            backgroundColor: 'rgba(13, 13, 16, 0.95)',
-            border: `1.5px solid ${accent}66`,
+      {/* Header row. The team-select control and the expand toggle are SIBLING
+          buttons inside this non-interactive flex container — never nested.
+          A <button> inside a <button> is invalid HTML (validateDOMNesting) and
+          collapses keyboard/AT semantics into a single ambiguous control. */}
+      <div className="expert-node w-full flex items-center gap-3 px-3.5 py-3 hover:bg-bg-hover/50 transition-colors">
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelectTeam();
           }}
+          onContextMenu={(e) => onTeamContextMenu(team, e)}
+          className="flex flex-1 min-w-0 items-center gap-3 text-left"
         >
-          {teamAvatar ? (
-            <span
-              className="twemoji leading-none pointer-events-none select-none"
-              style={{ fontSize: 28 }}
-              aria-label={teamAvatar.label}
-            >
-              {teamAvatar.emoji}
-            </span>
-          ) : (
-            <Users size={18} style={{ color: accent }} />
-          )}
-        </div>
-
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5">
-            <span className="text-sm font-semibold text-text-primary truncate" title={team.name}>
-              {team.name}
-            </span>
-            {team.isVerified && (
-              <BadgeCheck size={13} className="text-accent flex-shrink-0" strokeWidth={2.25} />
-            )}
-            {team.isPinned && <Pin size={11} className="text-accent flex-shrink-0" />}
-          </div>
-          <div className="flex items-center gap-1.5 mt-0.5">
-            <div
-              className="w-[6px] h-[6px] rounded-full flex-shrink-0"
-              style={{
-                backgroundColor: team.isEnabled ? '#22c55e' : '#71717a',
-              }}
-            />
-            <span className="text-[11px] text-text-tertiary truncate">
-              {subtitleParts.join(' · ')}
-            </span>
-          </div>
-        </div>
-
-        {/* Inline avatar cluster — only when collapsed, so the card is visually
-            complete at its natural (short) height rather than floating inside
-            a grid row stretched by expanded siblings. */}
-        {!expanded && memberCount > 0 && (
-          <div className="flex items-center flex-shrink-0">
-            <div className="flex -space-x-1.5">
-              {members.slice(0, 3).map((m) => {
-                const a = getAvatar(m.avatarUrl);
-                return (
-                  <div
-                    key={m.id}
-                    className="w-6 h-6 rounded-full border-2 border-bg-surface bg-bg-base overflow-hidden flex items-center justify-center"
-                    title={m.name}
-                  >
-                    {a ? (
-                      <span
-                        className="twemoji leading-none"
-                        style={{ fontSize: 14 }}
-                        aria-label={a.label}
-                      >
-                        {a.emoji}
-                      </span>
-                    ) : (
-                      <span className="text-[9px] text-text-tertiary">{m.name.slice(0, 1)}</span>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-            {memberCount > 3 && (
-              <span className="ml-1.5 text-[10px] text-text-tertiary tabular-nums">
-                +{memberCount - 3}
+          <div
+            className="relative w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0 overflow-hidden"
+            style={{
+              backgroundColor: 'rgba(13, 13, 16, 0.95)',
+              border: `1.5px solid ${accent}66`,
+            }}
+          >
+            {teamAvatar ? (
+              <span
+                className="twemoji leading-none pointer-events-none select-none"
+                style={{ fontSize: 28 }}
+                aria-label={teamAvatar.label}
+              >
+                {teamAvatar.emoji}
               </span>
+            ) : (
+              <Users size={18} style={{ color: accent }} />
             )}
           </div>
-        )}
+
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-1.5">
+              <span className="text-sm font-semibold text-text-primary truncate" title={team.name}>
+                {team.name}
+              </span>
+              {team.isVerified && (
+                <BadgeCheck size={13} className="text-accent flex-shrink-0" strokeWidth={2.25} />
+              )}
+              {team.isPinned && <Pin size={11} className="text-accent flex-shrink-0" />}
+            </div>
+            <div className="flex items-center gap-1.5 mt-0.5">
+              <div
+                className="w-[6px] h-[6px] rounded-full flex-shrink-0"
+                style={{
+                  backgroundColor: team.isEnabled ? '#22c55e' : '#71717a',
+                }}
+              />
+              <span className="text-[11px] text-text-tertiary truncate">
+                {subtitleParts.join(' · ')}
+              </span>
+            </div>
+          </div>
+
+          {/* Inline avatar cluster — only when collapsed, so the card is visually
+              complete at its natural (short) height rather than floating inside
+              a grid row stretched by expanded siblings. */}
+          {!expanded && memberCount > 0 && (
+            <div className="flex items-center flex-shrink-0">
+              <div className="flex -space-x-1.5">
+                {members.slice(0, 3).map((m) => {
+                  const a = getAvatar(m.avatarUrl);
+                  return (
+                    <div
+                      key={m.id}
+                      className="w-6 h-6 rounded-full border-2 border-bg-surface bg-bg-base overflow-hidden flex items-center justify-center"
+                      title={m.name}
+                    >
+                      {a ? (
+                        <span
+                          className="twemoji leading-none"
+                          style={{ fontSize: 14 }}
+                          aria-label={a.label}
+                        >
+                          {a.emoji}
+                        </span>
+                      ) : (
+                        <span className="text-[9px] text-text-tertiary">{m.name.slice(0, 1)}</span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+              {memberCount > 3 && (
+                <span className="ml-1.5 text-[10px] text-text-tertiary tabular-nums">
+                  +{memberCount - 3}
+                </span>
+              )}
+            </div>
+          )}
+        </button>
 
         <button
           type="button"
@@ -189,7 +195,7 @@ export default function DepartmentCard({
             )}
           />
         </button>
-      </button>
+      </div>
 
       {expanded &&
         (memberCount === 0 ? (

--- a/src/components/screens/experts/__tests__/DepartmentCard.test.tsx
+++ b/src/components/screens/experts/__tests__/DepartmentCard.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import DepartmentCard from '../DepartmentCard';
 import type { Expert } from '../../../../context/ExpertContext';
@@ -52,10 +52,7 @@ function makeExpert(overrides: Partial<Expert> = {}): Expert {
 }
 
 function renderCard(overrides: Partial<React.ComponentProps<typeof DepartmentCard>> = {}) {
-  const members = [
-    makeExpert({ id: 'm1', name: 'Alice' }),
-    makeExpert({ id: 'm2', name: 'Bob' }),
-  ];
+  const members = [makeExpert({ id: 'm1', name: 'Alice' }), makeExpert({ id: 'm2', name: 'Bob' })];
   const team = makeExpert({
     id: 't1',
     name: 'Engineering',

--- a/src/components/screens/experts/__tests__/DepartmentCard.test.tsx
+++ b/src/components/screens/experts/__tests__/DepartmentCard.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Regression test for issue #64 — "Experts > Hierarchy: Team cards nest the
+ * expand button inside the card button, firing a DOM error and breaking
+ * keyboard/AT semantics".
+ *
+ * The department/team card rendered the chevron expand/collapse <button> as a
+ * descendant of the outer team-select <button>. A <button> inside a <button>
+ * is invalid HTML: React emits a `validateDOMNesting` console error and
+ * assistive tech / keyboard tab order collapse the two controls into one.
+ *
+ * These tests pin the structural contract: the card header must expose two
+ * SIBLING buttons (select-team and expand-toggle), never one nested in the
+ * other, and clicking the chevron must toggle members without selecting the
+ * team.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import DepartmentCard from '../DepartmentCard';
+import type { Expert } from '../../../../context/ExpertContext';
+
+function makeExpert(overrides: Partial<Expert> = {}): Expert {
+  return {
+    id: 'e1',
+    slug: null,
+    name: 'Expert One',
+    domain: 'engineering',
+    description: '',
+    systemPrompt: null,
+    type: 'expert',
+    source: 'user',
+    isEnabled: true,
+    isPinned: false,
+    isVerified: false,
+    toolAccess: null,
+    policies: null,
+    requiredConnections: null,
+    recommendedRoutines: null,
+    teamMembers: null,
+    strategy: null,
+    coordinatorPrompt: null,
+    avatarUrl: null,
+    maxTurns: 10,
+    tokenBudget: 1000,
+    version: '1',
+    lastActiveAt: null,
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-01',
+    ...overrides,
+  } as Expert;
+}
+
+function renderCard(overrides: Partial<React.ComponentProps<typeof DepartmentCard>> = {}) {
+  const members = [
+    makeExpert({ id: 'm1', name: 'Alice' }),
+    makeExpert({ id: 'm2', name: 'Bob' }),
+  ];
+  const team = makeExpert({
+    id: 't1',
+    name: 'Engineering',
+    type: 'team',
+    teamMembers: [
+      { expertId: 'm1', role: 'Lead', order: 0 },
+      { expertId: 'm2', role: 'Dev', order: 1 },
+    ],
+  });
+  const props = {
+    team,
+    members,
+    isSelected: false,
+    selectedMemberId: null,
+    onSelectTeam: vi.fn(),
+    onSelectMember: vi.fn(),
+    onMemberContextMenu: vi.fn(),
+    onTeamContextMenu: vi.fn(),
+    ...overrides,
+  };
+  const result = render(<DepartmentCard {...props} />);
+  return { ...result, props };
+}
+
+describe('DepartmentCard (issue #64)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => cleanup());
+
+  it('does not nest a button inside another button', () => {
+    const { container } = renderCard();
+    // The core invalid-HTML bug: a <button> descendant of a <button>.
+    expect(container.querySelectorAll('button button')).toHaveLength(0);
+  });
+
+  it('renders the team-select and expand controls as independent buttons', () => {
+    const { container } = renderCard();
+    const expandBtn = screen.getByRole('button', { name: /collapse|expand/i });
+    expect(expandBtn).toBeInTheDocument();
+    // The expand toggle must not be contained by any other button.
+    expect(expandBtn.closest('button button')).toBeNull();
+    let nested = false;
+    container.querySelectorAll('button').forEach((b) => {
+      if (b.querySelector('button')) nested = true;
+    });
+    expect(nested).toBe(false);
+  });
+
+  it('does not emit a validateDOMNesting console error on render', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    renderCard();
+    const nestingError = errSpy.mock.calls.some((args) =>
+      args.some((a) => typeof a === 'string' && a.includes('validateDOMNesting')),
+    );
+    expect(nestingError).toBe(false);
+  });
+
+  it('toggling expand shows/hides members without selecting the team', () => {
+    const onSelectTeam = vi.fn();
+    renderCard({ onSelectTeam });
+    // Expanded by default: members visible.
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    const expandBtn = screen.getByRole('button', { name: /collapse/i });
+    fireEvent.click(expandBtn);
+    // Collapsed: members hidden, team not selected by the chevron click.
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+    expect(onSelectTeam).not.toHaveBeenCalled();
+  });
+
+  it('clicking the team header selects the team', () => {
+    const onSelectTeam = vi.fn();
+    renderCard({ onSelectTeam });
+    fireEvent.click(screen.getByText('Engineering'));
+    expect(onSelectTeam).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes #64.

## Summary

On Experts → Hierarchy, each team/department card rendered its expand-collapse chevron as a button nested inside the card's team-select button. A <button> inside a <button> is invalid HTML, so React emitted a DOM-nesting console error and the two controls collapsed into a single ambiguous target for keyboard and screen-reader users. The card now exposes the select and expand controls as two independent, separately-focusable buttons.

## Root cause

In src/components/screens/experts/DepartmentCard.tsx the header was a single outer <button> (onClick → onSelectTeam) that wrapped all of its contents, including a second inner <button> (the ChevronDown expand/collapse toggle, onClick → setExpanded). Nesting interactive elements violates HTML content models — React's validateDOMNesting flags it and AT/keyboard semantics merge the controls.

## Fix

- Convert the outer header <button> in DepartmentCard to a non-interactive <div> flex container so it no longer wraps another button.
- Move the team-select behavior (onClick/onContextMenu) onto an inner button that holds the avatar, name, subtitle, and collapsed avatar cluster.
- Keep the chevron expand/collapse as a sibling button of the select button — same styling and stopPropagation handlers, no nesting.

## Test plan

New `src/components/screens/experts/__tests__/DepartmentCard.test.tsx` covers:
- `does not nest a button inside another button` — container.querySelectorAll('button button') is empty
- `renders the team-select and expand controls as independent buttons` — the expand toggle exists and no button contains another button
- `does not emit a validateDOMNesting console error on render` — console.error receives no validateDOMNesting message
- `toggling expand shows/hides members without selecting the team` — clicking the chevron hides members and does not call onSelectTeam
- `clicking the team header selects the team` — clicking the team name calls onSelectTeam once

Manual verification: Ran the new vitest file (5/5 pass after fix; the two structural cases fail before it) plus the full frontend suite (1257 passed, 0 regressions) and the in-tree lint/format quality gates, all green.

## Notes

- A Playwright screenshot was not attempted because that surface needs a running Electron shell plus seeded team/expert data; the failing-then-passing jsdom UI test is the highest reliably reproducible rung here.
- node_modules was not present in the worktree, so I ran npm ci before testing — no dependency or lockfile changes were committed.

## Evidence

### Tests
- `patch` — 13040 bytes · sha256:feee2ab4bf0b · captured in the run audit log
- `failing_test_diff` — 13040 bytes · sha256:feee2ab4bf0b · captured in the run audit log
- `test_output` — 33 bytes · sha256:94ba302f9610 · captured in the run audit log
- `test_output` — 142 bytes · sha256:b064afe12578 · captured in the run audit log

### Screenshots
_Verified by an automated UI test — see the Test plan below._

### Logs
_(not applicable — no backend changes in this PR)_

### Reasoning
See the reasoning in this PR and the linked audit log.

---

_Co-authored by [Obelisk](https://github.com/HackerHouse-io/Obelisk)_ · _Reply `/obelisk explain` for the full reasoning trace._