### PR TITLE
fix: Routine editor shows "Saved" and drops edits when autosave PATCH fails

### DIFF
--- a/src/components/screens/routines/__tests__/useRoutineCanvas.autosave.test.tsx
+++ b/src/components/screens/routines/__tests__/useRoutineCanvas.autosave.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Regression test for issue #62 — the Routine editor shows "Saved" and silently
+ * drops the user's edits when the autosave PATCH fails.
+ *
+ * Root cause: RoutineContext.updateRoutine swallows every failure (network
+ * rejection or a non-ok HTTP response) and resolves normally. The autosave
+ * effect in useRoutineCanvas treated that resolution as success — it always ran
+ * setIsDirty(false) + setSaveStatus('saved'). So a failed save flipped the
+ * canvas to a clean "Saved" state even though nothing reached the backend, and
+ * because isDirty was cleared the edits were never retried and were lost on the
+ * next reload.
+ *
+ * The fix makes updateRoutine report success/failure (Promise<boolean>) and has
+ * the autosave / manual-save paths keep the canvas dirty and surface an "error"
+ * status when the write fails.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { Routine } from '../../../../types/routines';
+
+const updateRoutineMock = vi.fn();
+
+// The hook only needs updateRoutine from the routine context; stub the rest so
+// it can run without the full provider tree or the IPC bridge.
+vi.mock('../../../../context/RoutineContext', () => ({
+  useRoutines: () => ({ updateRoutine: updateRoutineMock }),
+}));
+
+import { useRoutineCanvas } from '../../../../hooks/useRoutineCanvas';
+
+function makeRoutine(overrides: Partial<Routine> = {}): Routine {
+  return {
+    id: 'r-1',
+    name: 'Test',
+    description: '',
+    plainEnglishSteps: null,
+    dagJson: null,
+    triggerType: 'manual',
+    cronExpression: null,
+    defaultRunnerId: null,
+    isEnabled: true,
+    approvalGates: null,
+    requiredConnections: null,
+    notifyChannels: null,
+    source: 'user',
+    sourceConversationId: null,
+    lastRunAt: null,
+    lastRunStatus: null,
+    runCount: 0,
+    createdAt: '',
+    updatedAt: '',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  updateRoutineMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useRoutineCanvas autosave failure (issue #62)', () => {
+  it('keeps the canvas dirty and shows an error when the autosave PATCH fails', async () => {
+    // A failing PATCH: updateRoutine resolves false (its failure contract).
+    updateRoutineMock.mockResolvedValue(false);
+
+    const { result } = renderHook(() => useRoutineCanvas(makeRoutine()));
+
+    // Make an edit so the canvas is dirty and autosave is scheduled.
+    act(() => {
+      result.current.addNode('signal', { x: 10, y: 10 });
+    });
+    expect(result.current.isDirty).toBe(true);
+
+    // Let the 1s autosave debounce fire and the async save settle.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1100);
+    });
+
+    expect(updateRoutineMock).toHaveBeenCalledTimes(1);
+    // The save failed: the editor must NOT claim "Saved" and must NOT drop the
+    // edit by clearing the dirty flag.
+    expect(result.current.saveStatus).toBe('error');
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it('reports "saved" and clears the dirty flag when the autosave PATCH succeeds', async () => {
+    updateRoutineMock.mockResolvedValue(true);
+
+    const { result } = renderHook(() => useRoutineCanvas(makeRoutine()));
+
+    act(() => {
+      result.current.addNode('signal', { x: 10, y: 10 });
+    });
+    expect(result.current.isDirty).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1100);
+    });
+
+    expect(updateRoutineMock).toHaveBeenCalledTimes(1);
+    expect(result.current.saveStatus).toBe('saved');
+    expect(result.current.isDirty).toBe(false);
+  });
+});

--- a/src/context/RoutineContext.tsx
+++ b/src/context/RoutineContext.tsx
@@ -33,7 +33,8 @@ interface RoutineContextValue {
   setEditingRoutineId: (id: string | null) => void;
   loadRoutines: () => Promise<void>;
   createRoutine: (input: CreateRoutineInput) => Promise<Routine | null>;
-  updateRoutine: (id: string, fields: Partial<ApiRoutine>) => Promise<void>;
+  /** Resolves true when the PATCH persisted, false when it failed. */
+  updateRoutine: (id: string, fields: Partial<ApiRoutine>) => Promise<boolean>;
   deleteRoutine: (id: string) => Promise<void>;
   toggleEnabled: (routine: Routine) => Promise<void>;
   runRoutine: (id: string) => Promise<void>;
@@ -121,7 +122,7 @@ export function RoutineProvider({ children }: { children: ReactNode }) {
   );
 
   const updateRoutine = useCallback(
-    async (id: string, fields: Partial<ApiRoutine>) => {
+    async (id: string, fields: Partial<ApiRoutine>): Promise<boolean> => {
       try {
         const res: BackendResponse<ApiRoutine> = await window.cerebro.invoke({
           method: 'PATCH',
@@ -134,10 +135,17 @@ export function RoutineProvider({ children }: { children: ReactNode }) {
           if (Object.keys(fields).some((k) => SCHEDULE_FIELDS.has(k))) {
             window.cerebro.scheduler.sync().catch(console.error);
           }
+          return true;
         }
+        // Non-ok HTTP response (e.g. 4xx/5xx). Treat as a failure so callers
+        // such as the autosave loop don't mistake it for a successful save.
+        console.error('Failed to update routine:', res);
+        addToast('Failed to update routine', 'error');
+        return false;
       } catch (e) {
         console.error('Failed to update routine:', e);
         addToast('Failed to update routine', 'error');
+        return false;
       }
     },
     [addToast],

--- a/src/hooks/useRoutineCanvas.ts
+++ b/src/hooks/useRoutineCanvas.ts
@@ -619,11 +619,18 @@ export function useRoutineCanvas(routine: Routine) {
       setSaveStatus('saving');
       try {
         const dag = serialize();
-        await updateRoutine(routine.id, { dag_json: JSON.stringify(dag) });
-        setIsDirty(false);
-        setSaveStatus('saved');
-        if (savedResetTimerRef.current) clearTimeout(savedResetTimerRef.current);
-        savedResetTimerRef.current = setTimeout(() => setSaveStatus('idle'), 2000);
+        const ok = await updateRoutine(routine.id, { dag_json: JSON.stringify(dag) });
+        if (ok) {
+          setIsDirty(false);
+          setSaveStatus('saved');
+          if (savedResetTimerRef.current) clearTimeout(savedResetTimerRef.current);
+          savedResetTimerRef.current = setTimeout(() => setSaveStatus('idle'), 2000);
+        } else {
+          // The PATCH didn't persist. Keep the canvas dirty so the edits aren't
+          // dropped (the next change re-triggers autosave) and surface the
+          // failure instead of a misleading "Saved".
+          setSaveStatus('error');
+        }
       } catch (err) {
         console.error('[Autosave] Failed:', err);
         setSaveStatus('error');
@@ -667,11 +674,17 @@ export function useRoutineCanvas(routine: Routine) {
     try {
       const dag = serialize();
       const dagJson = JSON.stringify(dag);
-      await updateRoutine(routine.id, { dag_json: dagJson });
-      setIsDirty(false);
-      setSaveStatus('saved');
-      if (savedResetTimerRef.current) clearTimeout(savedResetTimerRef.current);
-      savedResetTimerRef.current = setTimeout(() => setSaveStatus('idle'), 2000);
+      const ok = await updateRoutine(routine.id, { dag_json: dagJson });
+      if (ok) {
+        setIsDirty(false);
+        setSaveStatus('saved');
+        if (savedResetTimerRef.current) clearTimeout(savedResetTimerRef.current);
+        savedResetTimerRef.current = setTimeout(() => setSaveStatus('idle'), 2000);
+      } else {
+        // Save didn't persist — keep the canvas dirty and show the error so the
+        // user knows their changes are not yet stored.
+        setSaveStatus('error');
+      }
     } catch (err) {
       console.error('[Save] Failed:', err);
       setSaveStatus('error');


### PR DESCRIPTION
Fixes #62.

## Summary

In the Routine editor, autosave would report 'Saved' even when the underlying PATCH to the backend failed, and it cleared the dirty flag — so the user's edits were silently dropped and gone after a reload. This made a failed save indistinguishable from a successful one. The editor now shows an error and keeps the canvas dirty so edits aren't lost.

## Root cause

src/context/RoutineContext.tsx's updateRoutine swallowed all failures (both the catch path for network rejections and the non-ok HTTP-response path) and resolved with no value. The autosave effect and saveToBackend in src/hooks/useRoutineCanvas.ts awaited that always-resolving promise and unconditionally ran setIsDirty(false) + setSaveStatus('saved'); their catch branches were dead code because updateRoutine never threw.

## Fix

- Change updateRoutine in src/context/RoutineContext.tsx to return Promise<boolean> — true only when res.ok, false on a non-ok response or a thrown error (also toasting on the non-ok branch, which previously failed silently).
- Update the autosave effect in src/hooks/useRoutineCanvas.ts to check the boolean: on success clear dirty + show 'saved'; on failure leave isDirty true and set saveStatus to 'error'.
- Apply the same success/failure handling to the manual saveToBackend path so Ctrl/Cmd+S behaves identically.
- Update the RoutineContextValue interface's updateRoutine signature to Promise<boolean>.

## Test plan

New `src/components/screens/routines/__tests__/useRoutineCanvas.autosave.test.tsx` covers:
- `keeps the canvas dirty and shows an error when the autosave PATCH fails` — After an edit and the 1s debounce, with updateRoutine resolving false, saveStatus is 'error' and isDirty stays true
- `reports "saved" and clears the dirty flag when the autosave PATCH succeeds` — With updateRoutine resolving true, saveStatus is 'saved' and isDirty becomes false

Manual verification: Ran the new hook tests (red before the fix, green after), the full frontend suite (1254 passed incl. format:check + lint), and tsc --noEmit with no errors in the touched files.

## Notes

- Playwright/screenshot wasn't used: this is a desktop Electron app with no running dev server in the worktree, so the proof is an automated hook test that reproduces the failed-save flow (rung 2 of the ladder).
- node_modules was absent in the worktree; ran npm install to get the test runner, then reverted the incidental package-lock.json change so only the two source/test commits ship.

## Evidence

### Tests
- `patch` — 8469 bytes · sha256:736138d48a10 · captured in the run audit log
- `failing_test_diff` — 8469 bytes · sha256:736138d48a10 · captured in the run audit log
- `test_output` — 33 bytes · sha256:94ba302f9610 · captured in the run audit log
- `test_output` — 188 bytes · sha256:ccdddd0bc78f · captured in the run audit log

### Screenshots
_Verified by an automated UI test — see the Test plan below._

### Logs
_(not applicable — no backend changes in this PR)_

### Reasoning
See the reasoning in this PR and the linked audit log.

---

_Co-authored by [Obelisk](https://github.com/HackerHouse-io/Obelisk)_ · _Reply `/obelisk explain` for the full reasoning trace._